### PR TITLE
Textoverhaul

### DIFF
--- a/include/DxDefines.h
+++ b/include/DxDefines.h
@@ -25,10 +25,8 @@
 #include "DxBuildConfig.h"
 
 #include <stdint.h>
-
-#ifdef UNICODE
-#  include <wchar.h>
-#endif
+#include <stdarg.h>
+#include <wchar.h>
 
 #if defined(__GNUC__)
 #  define DXINLINE __inline__
@@ -89,16 +87,40 @@ typedef char TCHAR;
 #endif
 
 #ifndef NULL
-#define NULL (0)
+#  define NULL (0)
 #endif
 
 #ifndef DXINLINE
-#if defined(__GNUC__)
-#define DXINLINE __inline__
+#  if defined(__GNUC__)
+#    define DXINLINE __inline__
+#  else
+#    define DXINLINE __inline
+#  endif
+#endif
+
+#ifdef UNICODE
+#  define DXUNICALL(a) a ## W
 #else
-#define DXINLINE __inline
+#  define DXUNICALL(a) a ## A
 #endif
-#endif
+
+#define DXUNICALL_WRAP(func, params, tparams) \
+    static DXINLINE int func params { \
+        return DXUNICALL(func) tparams; \
+    }
+
+#define DXUNICALL_WRAPTO(func, params, funcTo, tparams) \
+    static DXINLINE int func params { \
+        return DXUNICALL(funcTo) tparams; \
+    }
+#define DXUNICALL_VA_WRAPTO(func, params, funcTo, tparams, argStart) \
+    static DXINLINE int func params { \
+        va_list args; \
+        va_start(args, argStart); \
+        int retval = DXUNICALL(funcTo) tparams; \
+        va_end(args); \
+        return retval; \
+    }
 
 #ifdef __cplusplus
 namespace DxLib {
@@ -109,16 +131,15 @@ namespace DxLib {
 #define DXLIB_VERSION_STR "3.11 "
 
 /* Various type macros and build defines */
-#define DXCHAR char
 #define DXCOLOR int
 #define DXTRUE (1)
 #define DXFALSE (0)
 
 #ifndef TRUE
-#define TRUE (1)
+#  define TRUE (1)
 #endif
 #ifndef FALSE
-#define FALSE (0)
+#  define FALSE (0)
 #endif
 
 /* Specify DLL export for all functions. */

--- a/include/DxDefines.h
+++ b/include/DxDefines.h
@@ -109,11 +109,7 @@ namespace DxLib {
 #define DXLIB_VERSION_STR "3.11 "
 
 /* Various type macros and build defines */
-#ifdef UNICODE
-#define DXCHAR wchar_t
-#else
 #define DXCHAR char
-#endif
 #define DXCOLOR int
 #define DXTRUE (1)
 #define DXFALSE (0)

--- a/include/DxLib.h
+++ b/include/DxLib.h
@@ -26,6 +26,9 @@
 
 // EXT_ is used for DxPortLib extensions.
 
+// All UNICODE support is handled in the header, so multiple libraries
+// are not required for different configurations.
+
 #include "DxBuildConfig.h"
 
 #ifdef DXPORTLIB_DXLIB_INTERFACE
@@ -69,7 +72,7 @@ extern DXCALL int WaitKey();
 extern DXCALL int GetDateTime(DATEDATA *dateBuf);
 
 // - Gets the time since program start, in milliseconds.
-extern DXCALL int GetNowCount(int UseRDTSCFlag = FALSE);
+extern DXCALL int GetNowCount(int UseRDTSCFlag = DXFALSE);
 
 // - Gets a random value from [0...RandMax]
 extern DXCALL int GetRand(int maxValue);
@@ -104,10 +107,16 @@ extern DXCALL int EXT_FileRead_SetCharSet(int charset);
 
 // - Opens a file stream handle to the given file.
 // Returns -1 on failure, otherwise returns the stream handle.
-extern DXCALL int FileRead_open(const DXCHAR *filename, int ASync = FALSE);
+extern DXCALL int FileRead_openW(const wchar_t *filename, int ASync = DXFALSE);
+extern DXCALL int FileRead_openA(const char *filename, int ASync = DXFALSE);
+DXUNICALL_WRAP(FileRead_open, (const TCHAR *filename, int ASync = DXFALSE),
+               (filename, ASync))
 
 // - Returns the size of the file.
-extern DXCALL int64_t FileRead_size(const DXCHAR *filename);
+extern DXCALL int64_t FileRead_sizeW(const wchar_t *filename);
+extern DXCALL int64_t FileRead_sizeA(const char *filename);
+DXUNICALL_WRAP(FileRead_size, (const TCHAR *filename),
+               (filename))
 
 // - Closes the file stream handle.
 extern DXCALL int FileRead_close(int fileHandle);
@@ -132,15 +141,33 @@ extern DXCALL int FileRead_read(void *data, int size, int fileHandle);
 extern DXCALL int FileRead_eof(int fileHandle);
 
 // - Reads a single line of text from the file, returns length.
-extern DXCALL int FileRead_gets(DXCHAR *buffer,
-                                int bufferSize, int fileHandle);
+extern DXCALL int FileRead_getsW(wchar_t *buffer,
+                                 int bufferSize, int fileHandle);
+extern DXCALL int FileRead_getsA(char *buffer,
+                                 int bufferSize, int fileHandle);
+DXUNICALL_WRAP(FileRead_gets, (TCHAR *buffer, int bufferSize, int fileHandle),
+               (buffer, bufferSize, fileHandle))
 
 // - Reads a single character.
-extern DXCALL DXCHAR FileRead_getc(int fileHandle);
+extern DXCALL wchar_t FileRead_getcW(int fileHandle);
+extern DXCALL char FileRead_getcA(int fileHandle);
+static DXINLINE TCHAR FileRead_getc(int fileHandle) {
+    return DXUNICALL(FileRead_getc)(fileHandle);
+}
+
+// - Performas a vscanf() on the next line of text in the file.
+extern DXCALL int FileRead_vscanfW(int fileHandle,
+                                  const wchar_t *format, va_list args);
+extern DXCALL int FileRead_vscanfA(int fileHandle,
+                                  const char *format, va_list args);
+DXUNICALL_WRAP(FileRead_vscanf,
+        (int fileHandle, const TCHAR *format, va_list args),
+        (fileHandle, format, args))
 
 // - Performas a scanf() on the next line of text in the file.
-extern DXCALL int FileRead_scanf(int fileHandle,
-                                 const DXCHAR *format, ...);
+DXUNICALL_VA_WRAPTO(
+    FileRead_scanf, (int fileHandle, const TCHAR *format, ...),
+    FileRead_vscanf, (fileHandle, format, args), format)
 
 // ---------------------------------------------------------- DxArchive.cpp
 // - If true, will attempt to load data from dirname.dxa.
@@ -148,33 +175,49 @@ extern DXCALL int FileRead_scanf(int fileHandle,
 extern DXCALL int SetUseDXArchiveFlag(int flag);
 
 // - Sets the encryption key to be used for DXA files.
-extern DXCALL int SetDXArchiveKeyString(const DXCHAR *keyString = NULL);
+extern DXCALL int SetDXArchiveKeyStringW(const wchar_t *keyString = NULL);
+extern DXCALL int SetDXArchiveKeyStringA(const char *keyString = NULL);
+DXUNICALL_WRAP(SetDXArchiveKeyString, (const TCHAR *keyString = NULL), (keyString))
 
 // - Sets the filename extension to be used for DXA files.
 // Default is "dxa".
 // NOTICE: Non-Windows platforms are case sensitive!
-extern DXCALL int SetDXArchiveExtension(const DXCHAR *extension = NULL);
+extern DXCALL int SetDXArchiveExtensionW(const wchar_t *extension = NULL);
+extern DXCALL int SetDXArchiveExtensionA(const char *extension = NULL);
+DXUNICALL_WRAP(SetDXArchiveExtension, (const TCHAR *extension = NULL), (extension))
 
 // - If FALSE, tries to load from dxa files then normal files.
 //   If TRUE, tries to load from normal files then dxa files.
 extern DXCALL int SetDXArchivePriority(int priority = 0);
 
 // - Preloads the dxa archive to memory.
-// NOTICE: async is not supported and will be ignored.
-extern DXCALL int DXArchivePreLoad(const DXCHAR *dxaFilename,
-                                   int async = DXFALSE);
+// NOTICE: async is not currently supported and will be ignored.
+extern DXCALL int DXArchivePreLoadW(const wchar_t *dxaFilename,
+                                    int async = DXFALSE);
+extern DXCALL int DXArchivePreLoadA(const char *dxaFilename,
+                                    int async = DXFALSE);
+DXUNICALL_WRAP(DXArchivePreLoad, (const TCHAR *dxaFilename, int async = DXFALSE),
+               (dxaFilename, async))
 
 // - Returns TRUE if preloading has been completed.
-// NOTICE: As async is not supported, this will always be TRUE.
-extern DXCALL int DXArchiveCheckIdle(const DXCHAR *dxaFilename);
+// NOTICE: As async is not currently supported, this will always be TRUE.
+extern DXCALL int DXArchiveCheckIdleW(const wchar_t *dxaFilename);
+extern DXCALL int DXArchiveCheckIdleA(const char *dxaFilename);
+DXUNICALL_WRAP(DXArchiveCheckIdle, (const TCHAR *dxaFilename), (dxaFilename))
 
 // - Releases the archive data from memory.
-extern DXCALL int DXArchiveRelease(const DXCHAR *dxaFilename);
+extern DXCALL int DXArchiveReleaseW(const wchar_t *dxaFilename);
+extern DXCALL int DXArchiveReleaseA(const char *dxaFilename);
+DXUNICALL_WRAP(DXArchiveRelease, (const TCHAR *dxaFilename), (dxaFilename))
 
 // - Returns TRUE if filename is contained within the
 //   archive pointed to by dxaFilename.
-extern DXCALL int DXArchiveCheckFile(const DXCHAR *dxaFilename,
-                                     const DXCHAR *filename);
+extern DXCALL int DXArchiveCheckFileW(const wchar_t *dxaFilename,
+                                      const wchar_t *filename);
+extern DXCALL int DXArchiveCheckFileA(const char *dxaFilename,
+                                      const char *filename);
+DXUNICALL_WRAP(DXArchiveCheckFile, (const TCHAR *dxaFilename, const TCHAR *filename),
+               (dxaFilename, filename))
 
 // ------------------------------------------------------------ DxInput.cpp
 #ifndef DX_NON_INPUT
@@ -235,10 +278,10 @@ extern DXCALL int SetValidMousePointerWindowOutClientAreaMoveFlag(int flag);
 
 // - Gets the Vertical or Horizontal mouse wheel states.
 // If clearFlag, resets internal value to zero.
-extern DXCALL int GetMouseWheelRotVol(int clearFlag = TRUE);
-extern DXCALL int GetMouseHWheelRotVol(int clearFlag = TRUE);
-extern DXCALL float GetMouseWheelRotVolF(int clearFlag = TRUE);
-extern DXCALL float GetMouseHWheelRotVolF(int clearFlag = TRUE);
+extern DXCALL int GetMouseWheelRotVol(int clearFlag = DXTRUE);
+extern DXCALL int GetMouseHWheelRotVol(int clearFlag = DXTRUE);
+extern DXCALL float GetMouseWheelRotVolF(int clearFlag = DXTRUE);
+extern DXCALL float GetMouseHWheelRotVolF(int clearFlag = DXTRUE);
 
 #endif /* #ifndef DX_NON_INPUT */
 
@@ -252,7 +295,7 @@ extern DXCALL int SetGraphMode(int width, int height,
 // - Sets if the window can be resized or not.
 // NOTICE: Can only be set before DxLib_Init is called!
 extern DXCALL int SetWindowSizeChangeEnableFlag(int windowResizeFlag,
-                                                int fitScreen = TRUE);
+                                                int fitScreen = DXTRUE);
 
 // Avoid conflicts with windows headers that will define SetWindowText.
 #ifdef SetWindowText
@@ -260,8 +303,13 @@ extern DXCALL int SetWindowSizeChangeEnableFlag(int windowResizeFlag,
 #endif
 
 // - Sets the title of the window.
-extern DXCALL int SetWindowText(const DXCHAR *windowName);
-extern DXCALL int SetMainWindowText(const DXCHAR *windowName);
+extern DXCALL int SetWindowTextW(const wchar_t *windowName);
+extern DXCALL int SetWindowTextA(const char *windowName);
+DXUNICALL_WRAP(SetWindowText, (const TCHAR *windowName), (windowName))
+
+// - SetMainWindowText is an alias for SetWindowText.
+DXUNICALL_WRAPTO(SetMainWindowText, (const TCHAR *windowName),
+                 SetWindowText, (windowName))
 
 // - Flips the backbuffer to the front buffer.
 // Call when drawing operations for a frame are finished.
@@ -289,7 +337,9 @@ extern DXCALL int GetWaitVSyncFlag();
 
 // - DxPortLib Extension: Sets the icon file to use.
 // NOTICE: Cannot use resource icons. Supply a .png.
-extern DXCALL int EXT_SetIconImageFile(const DXCHAR *filename);
+extern DXCALL int EXT_SetIconImageFileW(const wchar_t *filename);
+extern DXCALL int EXT_SetIconImageFileA(const char *filename);
+DXUNICALL_WRAP(EXT_SetIconImageFile, (const TCHAR *filename), (filename))
 
 // - If TRUE, runs even if the window is not focused.
 // Default is FALSE.
@@ -307,56 +357,109 @@ extern DXCALL int GetWindowActiveFlag();
 extern DXCALL int GetActiveFlag();
 
 // - Creates an error message box.
-extern DXCALL int EXT_MessageBoxError(const DXCHAR *title,
-                                      const DXCHAR *text);
+extern DXCALL int EXT_MessageBoxErrorW(const wchar_t *title,
+                                       const wchar_t *text);
+extern DXCALL int EXT_MessageBoxErrorA(const char *title,
+                                       const char *text);
+DXUNICALL_WRAP(EXT_MessageBoxError, (const TCHAR *title, const TCHAR *text),
+               (title, text))
+
 // - Creates a message box asking a yes/no question.
 // Default selected button is button1.
 // MessageBoxYesNo returns -1 on error, 0 for button1, 1 for button2.
-extern DXCALL int EXT_MessageBoxYesNo(const DXCHAR *title,
-                                      const DXCHAR *text,
-                                      const DXCHAR *button1,
-                                      const DXCHAR *button2);
+extern DXCALL int EXT_MessageBoxYesNoW(const wchar_t *title,
+                                       const wchar_t *text,
+                                       const wchar_t *button1,
+                                       const wchar_t *button2);
+extern DXCALL int EXT_MessageBoxYesNoA(const char *title,
+                                       const char *text,
+                                       const char *button1,
+                                       const char *button2);
+DXUNICALL_WRAP(EXT_MessageBoxYesNo,
+               (const TCHAR *title, const TCHAR *text,
+                const TCHAR *button1, const TCHAR *button2),
+               (title, text, button1, button2))
 
 // --------------------------------------------------------- DxGraphics.cpp
 // - Creates a screen graph that can be used with SetDrawScreen.
 // Note that you can't use it to draw with while bound.
 extern DXCALL int MakeScreen(int width, int height,
-                             int hasAlphaChannel = FALSE);
+                             int hasAlphaChannel = DXFALSE);
 
 // - Loads the given image file into the returned handle.
-extern DXCALL int LoadGraph(const DXCHAR *name,
-                            int notUse3DFlag = FALSE);
+extern DXCALL int LoadGraphW(const wchar_t *name,
+                             int notUse3DFlag = DXFALSE);
+extern DXCALL int LoadGraphA(const char *name,
+                             int notUse3DFlag = DXFALSE);
+DXUNICALL_WRAP(LoadGraph, (const TCHAR *name, int NotUse3DFlag = DXFALSE),
+               (name, NotUse3DFlag))
 
 // - Loads the given image flipped horizontally into the returned handle.
-extern DXCALL int LoadReverseGraph(const DXCHAR *name,
-                                   int notUse3DFlag = FALSE);
+extern DXCALL int LoadReverseGraphW(const wchar_t *name,
+                                    int notUse3DFlag = DXFALSE);
+extern DXCALL int LoadReverseGraphA(const char *name,
+                                    int notUse3DFlag = DXFALSE);
+DXUNICALL_WRAP(LoadReverseGraph, (const TCHAR *name, int NotUse3DFlag = DXFALSE),
+               (name, NotUse3DFlag))
 
 // - Loads an image, and then derives into graphCount graphics handles,
 //   placing them into handleBuf.
 // e.g.:
 //   int handles[16];
 //   LoadDivGraph("image.png", 16, 4, 4, 64, 64, handles);
-extern DXCALL int LoadDivGraph(
-                          const DXCHAR *filename, int graphCount,
+extern DXCALL int LoadDivGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
-                          int *handleBuf,
-                          int notUse3DFlag = FALSE);
-extern DXCALL int LoadDivBmpGraph(
-                          const DXCHAR *filename, int graphCount,
+                          int *handleBuf, int notUse3DFlag = DXFALSE);
+extern DXCALL int LoadDivGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf, int notUse3DFlag = DXFALSE);
+DXUNICALL_WRAP(LoadDivGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int notUse3DFlag = DXFALSE),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, notUse3DFlag))
+
+extern DXCALL int LoadDivBmpGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf, int textureFlag, int flipFlag);
-extern DXCALL int LoadReverseDivGraph(
-                          const DXCHAR *filename, int graphCount,
+extern DXCALL int LoadDivBmpGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf, int textureFlag, int flipFlag);
+DXUNICALL_WRAP(LoadDivBmpGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int textureFlag, int flipFlag),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, textureFlag, flipFlag))
+
+extern DXCALL int LoadReverseDivGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf,
-                          int notUse3DFlag = FALSE);
+                          int notUse3DFlag = DXFALSE);
+extern DXCALL int LoadReverseDivGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf,
+                          int notUse3DFlag = DXFALSE);
+DXUNICALL_WRAP(LoadReverseDivGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int notUse3DFlag = DXFALSE),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, notUse3DFlag))
 
 // - Deletes a Graph handle.
-extern DXCALL int DeleteGraph(int graphID, int LogOutFlag = FALSE);
+extern DXCALL int DeleteGraph(int graphID, int LogOutFlag = DXFALSE);
 // - Deletes all graph handles that were based on the same graph as this.
 extern DXCALL int DeleteSharingGraph(int graphID);
 // - Deletes ALL Graph handles.
-extern DXCALL int InitGraph(int LogOutFlag = FALSE);
+extern DXCALL int InitGraph(int LogOutFlag = DXFALSE);
 
 // - Gets the number of currently active graphs.
 extern DXCALL int GetGraphNum();
@@ -421,9 +524,9 @@ extern DXCALL int DrawLineBoxF(float x1, float y1, float x2, float y2,
 
 // - Draws a circle centered at (x,y), with radius r.
 extern DXCALL int DrawCircle(int x, int y, int r,
-                             DXCOLOR color, int fillFlag = TRUE);
+                             DXCOLOR color, int fillFlag = DXTRUE);
 extern DXCALL int DrawCircleF(float x, float y, float r,
-                              DXCOLOR color, int fillFlag = TRUE);
+                              DXCOLOR color, int fillFlag = DXTRUE);
 // - Draws an ellipse centered at (x,y), with extents (rx,ry).
 extern DXCALL int DrawOval(int x, int y, int rx, int ry,
                            DXCOLOR color, int fillFlag);
@@ -580,24 +683,64 @@ extern DXCALL int ClearDrawScreen(const RECT *clearRect = NULL);
 extern DXCALL int ClsDrawScreen();
 
 // - Saves a region of the current screen to an image file.
-extern DXCALL int SaveDrawScreen(int x1, int y1, int x2, int y2,
-                                 const DXCHAR *filename,
-                                 int saveType = DX_IMAGESAVETYPE_BMP,
-                                 int jpegQuality = 80,
-                                 int jpegSample2x1 = DXTRUE,
-                                 int pngCompressionLevel = -1);
-extern DXCALL int SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                                      const DXCHAR *filename);
-extern DXCALL int SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                                       const DXCHAR *filename,
-                                       int quality = 80,
-                                       int sample2x1 = DXTRUE);
-extern DXCALL int SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                                      const DXCHAR *filename,
-                                      int compressionLevel = -1);
+extern DXCALL int SaveDrawScreenW(int x1, int y1, int x2, int y2,
+                                  const wchar_t *filename,
+                                  int saveType = DX_IMAGESAVETYPE_BMP,
+                                  int jpegQuality = 80,
+                                  int jpegSample2x1 = DXTRUE,
+                                  int pngCompressionLevel = -1);
+extern DXCALL int SaveDrawScreenA(int x1, int y1, int x2, int y2,
+                                  const char *filename,
+                                  int saveType = DX_IMAGESAVETYPE_BMP,
+                                  int jpegQuality = 80,
+                                  int jpegSample2x1 = DXTRUE,
+                                  int pngCompressionLevel = -1);
+DXUNICALL_WRAP(SaveDrawScreen,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename,
+                int saveType = DX_IMAGESAVETYPE_BMP,
+                int jpegQuality = 80, int jpegSample2x1 = DXTRUE,
+                int pngCompressionLevel = -1),
+               (x1, y1, x2, y2, filename, saveType,
+                jpegQuality, jpegSample2x1, pngCompressionLevel))
+
+extern DXCALL int SaveDrawScreenToBMPW(int x1, int y1, int x2, int y2,
+                                       const wchar_t *filename);
+extern DXCALL int SaveDrawScreenToBMPA(int x1, int y1, int x2, int y2,
+                                       const char *filename);
+DXUNICALL_WRAP(SaveDrawScreenToBMP,
+               (int x1, int y1, int x2, int y2, const TCHAR *filename),
+               (x1, y1, x2, y2, filename))
+
+extern DXCALL int SaveDrawScreenToJPEGW(int x1, int y1, int x2, int y2,
+                                        const wchar_t *filename,
+                                        int quality = 80,
+                                        int sample2x1 = DXTRUE);
+extern DXCALL int SaveDrawScreenToJPEGA(int x1, int y1, int x2, int y2,
+                                        const char *filename,
+                                        int quality = 80,
+                                        int sample2x1 = DXTRUE);
+DXUNICALL_WRAP(SaveDrawScreenToJPEG,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename, int quality = 80,
+                int sample2x1 = DXTRUE),
+               (x1, y1, x2, y2, filename, quality, sample2x1))
+
+extern DXCALL int SaveDrawScreenToPNGW(int x1, int y1, int x2, int y2,
+                                       const wchar_t *filename,
+                                       int compressionLevel = -1);
+extern DXCALL int SaveDrawScreenToPNGA(int x1, int y1, int x2, int y2,
+                                       const char *filename,
+                                       int compressionLevel = -1);
+DXUNICALL_WRAP(SaveDrawScreenToPNG,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename, int compressionLevel = -1),
+               (x1, y1, x2, y2, filename, compressionLevel))
 
 // - Given the three RGB components, returns a color value.
-extern DXCALL DXCOLOR GetColor(int red, int green, int blue);
+static DXINLINE DXCOLOR GetColor(int red, int green, int blue) {
+    return red | (green << 8) | (blue << 16);
+}
 
 // ------------------------------------------------------------- DxFont.cpp
 #ifndef DX_NON_FONT
@@ -608,13 +751,25 @@ extern DXCALL DXCOLOR GetColor(int red, int green, int blue);
 //   bolded.
 //   exRateX/exRateY are a global Extend multiplier used.
 // NOTICE: This must be used for all fonts.
-extern DXCALL int EXT_MapFontFileToName(const DXCHAR *filename,
-                                        const DXCHAR *fontname,
-                                        int thickness,
-                                        int boldFlag,
-                                        double exRateX = 1.0,
-                                        double exRateY = 1.0
-                                        );
+extern DXCALL int EXT_MapFontFileToNameW(const wchar_t *filename,
+                                         const wchar_t *fontname,
+                                         int thickness,
+                                         int boldFlag,
+                                         double exRateX = 1.0,
+                                         double exRateY = 1.0);
+extern DXCALL int EXT_MapFontFileToNameA(const char *filename,
+                                         const char *fontname,
+                                         int thickness,
+                                         int boldFlag,
+                                         double exRateX = 1.0,
+                                         double exRateY = 1.0);
+DXUNICALL_WRAP(EXT_MapFontFileToName,
+               (const TCHAR *filename, const TCHAR *fontname,
+                int thickness, int boldFlag,
+                double exRateX = 1.0, double exRateY = 1.0),
+               (filename, fontname, thickness, boldFlag,
+                exRateX, exRateY))
+
 // - DxPortLib Extension.
 //   Deletes all existing font mappings.
 //   Will not delete font handles.
@@ -623,59 +778,151 @@ extern DXCALL int EXT_InitFontMappings();
 // ------ Font handle functions
 
 // - Draws a string at the given position, with the given font and color.
-extern DXCALL int DrawStringToHandle(int x, int y, const DXCHAR *string,
-                                     DXCOLOR color, int fontHandle,
-                                     DXCOLOR edgeColor = 0,
-                                     int VerticalFlag = FALSE);
-extern DXCALL int DrawFormatStringToHandle(
+extern DXCALL int DrawStringToHandleW(int x, int y, const wchar_t *string,
+                                      DXCOLOR color, int fontHandle,
+                                      DXCOLOR edgeColor = 0,
+                                      int VerticalFlag = DXFALSE);
+extern DXCALL int DrawStringToHandleA(int x, int y, const char *string,
+                                      DXCOLOR color, int fontHandle,
+                                      DXCOLOR edgeColor = 0,
+                                      int VerticalFlag = DXFALSE);
+DXUNICALL_WRAP(DrawStringToHandle,
+               (int x, int y, const TCHAR *string,
+                DXCOLOR color, int fontHandle,
+                DXCOLOR edgeColor = 0,
+                int VerticalFlag = DXFALSE),
+               (x, y, string, color, fontHandle,
+                edgeColor, VerticalFlag))
+
+extern DXCALL int DrawFormatVStringToHandleA(
                                      int x, int y, DXCOLOR color,
                                      int fontHandle,
-                                     const DXCHAR *formatString, ...);
+                                     const char *formatString, va_list args);
+extern DXCALL int DrawFormatVStringToHandleW(
+                                     int x, int y, DXCOLOR color,
+                                     int fontHandle,
+                                     const wchar_t *formatString, va_list args);
+DXUNICALL_VA_WRAPTO(DrawFormatStringToHandle,
+                    (int x, int y, DXCOLOR color,
+                     int fontHandle,
+                     const TCHAR *formatString, ...),
+                    DrawFormatVStringToHandle,
+                    (x, y, color, fontHandle, formatString, args),
+                    formatString)
+
 // - Draws a scaled string at the given position, with the given font/color.
-extern DXCALL int DrawExtendStringToHandle(double ExRateX,
-                                           double ExRateY,
+extern DXCALL int DrawExtendStringToHandleA(double ExRateX, double ExRateY,
+                                            int x, int y,
+                                            const char *string,
+                                            DXCOLOR color, int fontHandle,
+                                            DXCOLOR edgeColor = 0,
+                                            int VerticalFlag = DXFALSE);
+extern DXCALL int DrawExtendStringToHandleW(double ExRateX, double ExRateY,
+                                            int x, int y,
+                                            const wchar_t *string,
+                                            DXCOLOR color,
+                                            int fontHandle,
+                                            DXCOLOR edgeColor = 0,
+                                            int VerticalFlag = DXFALSE);
+DXUNICALL_WRAP(DrawExtendStringToHandle,
+               (double ExRateX, double ExRateY, int x, int y,
+                const TCHAR *string, DXCOLOR color, int fontHandle,
+                DXCOLOR edgeColor = 0, int VerticalFlag = DXFALSE),
+               (ExRateX, ExRateY, x, y, string,
+                color, fontHandle, edgeColor, VerticalFlag))
+
+extern DXCALL int DrawExtendFormatVStringToHandleA(
+                                           double ExRateX, double ExRateY,
                                            int x, int y,
-                                           const DXCHAR *string,
                                            DXCOLOR color,
                                            int fontHandle,
-                                           DXCOLOR edgeColor = 0,
-                                           int VerticalFlag = FALSE);
-extern DXCALL int DrawExtendFormatStringToHandle(
-                                           double ExRateX,
-                                           double ExRateY,
+                                           const char *formatString, va_list args);
+extern DXCALL int DrawExtendFormatVStringToHandleW(
+                                           double ExRateX, double ExRateY,
                                            int x, int y,
                                            DXCOLOR color,
                                            int fontHandle,
-                                           const DXCHAR *formatString,
-                                           ...);
+                                           const wchar_t *formatString, va_list args);
+DXUNICALL_VA_WRAPTO(DrawExtendFormatStringToHandle,
+                    (double ExRateX, double ExRateY, int x, int y,
+                     DXCOLOR color, int fontHandle, const TCHAR *formatString, ...),
+                    DrawExtendFormatVStringToHandle,
+                    (ExRateX, ExRateY, x, y,
+                     color, fontHandle, formatString, args),
+                    formatString)
 
 // - Gets the width of a string that would be drawn.
-extern DXCALL int GetDrawStringWidthToHandle(const DXCHAR *string,
+extern DXCALL int GetDrawStringWidthToHandleA(const char *string,
                                              int strLen, int fontHandle,
-                                             int VerticalFlag = FALSE);
-extern DXCALL int GetDrawFormatStringWidthToHandle(int fontHandle,
-                                                   const DXCHAR *string,
-                                                   ...);
+                                             int VerticalFlag = DXFALSE);
+extern DXCALL int GetDrawStringWidthToHandleW(const wchar_t *string,
+                                             int strLen, int fontHandle,
+                                             int VerticalFlag = DXFALSE);
+DXUNICALL_WRAP(GetDrawStringWidthToHandle,
+               (const TCHAR *string, int strLen, int fontHandle,
+                int VerticalFlag = DXFALSE),
+               (string, strLen, fontHandle, VerticalFlag))
+
+extern DXCALL int GetDrawFormatVStringWidthToHandleA(int fontHandle,
+                                                     const char *string,
+                                                     va_list args);
+extern DXCALL int GetDrawFormatVStringWidthToHandleW(int fontHandle,
+                                                     const wchar_t *string,
+                                                     va_list args);
+DXUNICALL_VA_WRAPTO(GetDrawFormatStringWidthToHandle,
+                    (int fontHandle, const TCHAR *string, ...),
+                    GetDrawFormatVStringWidthToHandle,
+                    (fontHandle, string, args),
+                    string)
+
 // - Gets the scaled width of a string that would be drawn.
-extern DXCALL int GetDrawExtendStringWidthToHandle(double ExRateX,
-                                                   const DXCHAR *string,
-                                                   int strLen,
-                                                   int fontHandle,
-                                                   int VerticalFlag = FALSE);
-extern DXCALL int GetDrawExtendFormatStringWidthToHandle(
+extern DXCALL int GetDrawExtendStringWidthToHandleA(double ExRateX,
+                                                    const char *string,
+                                                    int strLen,
+                                                    int fontHandle,
+                                                    int VerticalFlag = DXFALSE);
+extern DXCALL int GetDrawExtendStringWidthToHandleW(double ExRateX,
+                                                    const wchar_t *string,
+                                                    int strLen,
+                                                    int fontHandle,
+                                                    int VerticalFlag = DXFALSE);
+DXUNICALL_WRAP(GetDrawExtendStringWidthToHandle,
+               (double ExRateX, const TCHAR *string,
+                int strLen, int fontHandle, int VerticalFlag = DXFALSE),
+               (ExRateX, string, strLen, fontHandle, VerticalFlag))
+
+extern DXCALL int GetDrawExtendFormatVStringWidthToHandleA(
                                                    double ExRateX,
                                                    int fontHandle,
-                                                   const DXCHAR *string,
-                                                   ...);
+                                                   const char *string,
+                                                   va_list args);
+extern DXCALL int GetDrawExtendFormatVStringWidthToHandleW(
+                                                   double ExRateX,
+                                                   int fontHandle,
+                                                   const wchar_t *string,
+                                                   va_list args);
+DXUNICALL_VA_WRAPTO(GetDrawExtendFormatStringWidthToHandle,
+                    (double ExRateX, int fontHandle, const TCHAR *string, ...),
+                    GetDrawExtendFormatVStringWidthToHandle,
+                    (ExRateX, fontHandle, string, args),
+                    string)
 
 // - Gets the font handle's size.
 extern DXCALL int GetFontSizeToHandle(int fontHandle);
 
 // - Gets the dimensions and advance information of the first
 //   character of the given string.
-extern DXCALL int GetFontCharInfo(int fontHandle, const DXCHAR *string,
-                                  int *xPos, int *yPos, int *advanceX,
-                                  int *width, int *height);
+extern DXCALL int GetFontCharInfoA(int fontHandle, const char *string,
+                                   int *xPos, int *yPos, int *advanceX,
+                                   int *width, int *height);
+extern DXCALL int GetFontCharInfoW(int fontHandle, const wchar_t *string,
+                                   int *xPos, int *yPos, int *advanceX,
+                                   int *width, int *height);
+DXUNICALL_WRAP(GetFontCharInfo,
+               (int fontHandle, const TCHAR *string,
+                int *xPos, int *yPos, int *advanceX,
+                int *width, int *height),
+               (fontHandle, string, xPos, yPos, advanceX, width, height))
 
 // - Sets the spacing between characters for a font handle.
 // Negative values are valid.
@@ -693,12 +940,23 @@ extern DXCALL int SetFontSpaceToHandle(int fontSpacing, int fontHandle);
 // edgeSize is valid for DX_FONTTYPE*_EDGE and may be 1 through 4.
 //   Default edgeSize is 1.
 // italics draws the font italicized. default is DXFALSE.
-extern DXCALL int CreateFontToHandle(const DXCHAR *fontname,
-                                     int size, int thickness,
-                                     int fontType = -1, int charset = -1,
-                                     int edgeSize = -1, int italic = DXFALSE,
-                                     int handle = -1
-                                     );
+extern DXCALL int CreateFontToHandleW(const wchar_t *fontname,
+                                      int size, int thickness,
+                                      int fontType = -1, int charset = -1,
+                                      int edgeSize = -1, int italic = DXFALSE,
+                                      int handle = -1);
+extern DXCALL int CreateFontToHandleA(const char *fontname,
+                                      int size, int thickness,
+                                      int fontType = -1, int charset = -1,
+                                      int edgeSize = -1, int italic = DXFALSE,
+                                      int handle = -1);
+DXUNICALL_WRAP(CreateFontToHandle,
+               (const TCHAR *fontname, int size, int thickness,
+                int fontType = -1, int charset = -1, int edgeSize = -1,
+                int italic = DXFALSE, int handle = -1),
+               (fontname, size, thickness, fontType, charset, edgeSize,
+                italic, handle))
+
 // - Deletes a font handle.
 extern DXCALL int DeleteFontToHandle(int handle);
 // - Returns TRUE if a font handle is still valid.
@@ -711,7 +969,11 @@ extern DXCALL int InitFontToHandle();
 
 // ------ "Default" font functions
 // DxPortLib maintains a font handle internally for the default font.
-// NOTICE: Unliked DxLib, there is no font set by default!
+// NOTICE: Unlike DxLib, there is no font set by default!
+//
+// Most of these functions do not actually exist in code, and are aliases
+// that grab the current default font handle and use that. The C version
+// includes some basic hardcoded aliases for external linking.
 // 
 // Changing any font information will cause it to refresh that font handle
 // the next time it is used, which is slow.
@@ -722,39 +984,70 @@ extern DXCALL int InitFontToHandle();
 // You should set this only once in your program and then use handles
 // for everything else.
 
+// - Gets the current default font handle.
+// NOTICE: This will change if the font is changed.
+extern DXCALL int GetDefaultFontHandle();
+
 // - Draws a string with the default font to (x,y).
-extern DXCALL int DrawString(int x, int y,
-                             const DXCHAR *string,
-                             DXCOLOR color, DXCOLOR edgeColor = 0);
-extern DXCALL int DrawFormatString(int x, int y,
-                                   DXCOLOR color,
-                                   const DXCHAR *formatString, ...);
+DXUNICALL_WRAPTO(DrawString, 
+                 (int x, int y, const TCHAR *string,
+                  DXCOLOR color, DXCOLOR edgeColor = 0),
+                 DrawStringToHandle,
+                 (x, y, string, color, GetDefaultFontHandle(),
+                  edgeColor, FALSE))
+DXUNICALL_VA_WRAPTO(DrawFormatString, 
+                    (int x, int y, DXCOLOR color, const TCHAR *formatString, ...),
+                    DrawFormatVStringToHandle,
+                    (x, y, color, GetDefaultFontHandle(), formatString, args),
+                    formatString)
 
 // - Draws a scaled string with the default font.
-extern DXCALL int DrawExtendString(int x, int y,
-                                   double ExRateX, double ExRateY,
-                                   const DXCHAR *string,
-                                   DXCOLOR color, DXCOLOR edgeColor = 0);
-extern DXCALL int DrawExtendFormatString(int x, int y,
-                                         double ExRateX, double ExRateY,
-                                         DXCOLOR color,
-                                         const DXCHAR *formatString, ...);
+DXUNICALL_WRAPTO(DrawExtendString,
+                 (int x, int y, double ExRateX, double ExRateY,
+                  const TCHAR *string, DXCOLOR color, DXCOLOR edgeColor = 0),
+                 DrawExtendStringToHandle,
+                 (ExRateX, ExRateY, x, y, string, color,
+                  GetDefaultFontHandle(), edgeColor, FALSE))
+DXUNICALL_VA_WRAPTO(DrawExtendFormatString,
+                    (int x, int y, double ExRateX, double ExRateY,
+                     DXCOLOR color, const TCHAR *formatString, ...),
+                    DrawExtendFormatVStringToHandle,
+                    (ExRateX, ExRateY, x, y, color,
+                     GetDefaultFontHandle(), formatString, args),
+                    formatString)
 
 // - Gets the width of a string using the default font.
-extern DXCALL int GetDrawStringWidth(const DXCHAR *string, int strLen,
-                                     int VerticalFlag = FALSE);
-extern DXCALL int GetDrawFormatStringWidth(const DXCHAR *string, ...);
+DXUNICALL_WRAPTO(GetDrawStringWidth,
+                 (const TCHAR *string, int strLen, int VerticalFlag = DXFALSE),
+                 GetDrawStringWidthToHandle,
+                 (string, strLen, GetDefaultFontHandle(), VerticalFlag))
+DXUNICALL_VA_WRAPTO(GetDrawFormatStringWidth,
+                    (const TCHAR *string, ...),
+                    GetDrawFormatVStringWidthToHandle,
+                    (GetDefaultFontHandle(), string, args),
+                    string)
 
 // - Gets the scaled width of a string using the default font.
-extern DXCALL int GetDrawExtendStringWidth(double ExRateX,
-                                           const DXCHAR *string,
-                                           int strLen,
-                                           int VerticalFlag = FALSE);
-extern DXCALL int GetDrawExtendFormatStringWidth(double ExRateX,
-                                                 const DXCHAR *string, ...);
+DXUNICALL_WRAPTO(GetDrawExtendStringWidth,
+                 (double ExRateX, const TCHAR *string,
+                  int strLen, int VerticalFlag = DXFALSE),
+                 GetDrawExtendStringWidthToHandle,
+                 (ExRateX, string, strLen,
+                  GetDefaultFontHandle(), VerticalFlag))
+
+DXUNICALL_VA_WRAPTO(GetDrawExtendFormatStringWidth,
+                    (double ExRateX, const TCHAR *string, ...),
+                    GetDrawExtendFormatVStringWidthToHandle,
+                    (ExRateX, GetDefaultFontHandle(), string, args),
+                    string)
 
 // - Changes the default font and charset.
-extern DXCALL int ChangeFont(const DXCHAR *fontName, int charSet = -1);
+extern DXCALL int ChangeFontW(const wchar_t *fontName, int charSet = -1);
+extern DXCALL int ChangeFontA(const char *fontName, int charSet = -1);
+DXUNICALL_WRAP(ChangeFont,
+               (const TCHAR *fontName, int charSet = -1),
+               (fontName, charSet))
+
 // - Changes the default font type.
 extern DXCALL int ChangeFontType(int fontType);
 
@@ -767,12 +1060,13 @@ extern DXCALL int SetFontThickness(int fontThickness);
 // - Sets the default font's spacing.
 extern DXCALL int SetFontSpace(int fontSpace);
 // - Sets the default font's name, size, and thickness all at once.
-extern DXCALL int SetDefaultFontState(const DXCHAR *fontName,
-                                      int fontSize, int fontThickness);
-
-// - Gets the current default font handle.
-// NOTICE: This will change if the font is changed.
-extern DXCALL int GetDefaultFontHandle();
+extern DXCALL int SetDefaultFontStateW(const wchar_t *fontName,
+                                       int fontSize, int fontThickness);
+extern DXCALL int SetDefaultFontStateA(const char *fontName,
+                                       int fontSize, int fontThickness);
+DXUNICALL_WRAP(SetDefaultFontState,
+               (const TCHAR *fontName, int fontSize, int fontThickness),
+               (fontName, fontSize, fontThickness))
 
 // - Sets if font textures will be generated with premultiplied alpha.
 // Default is FALSE.
@@ -810,18 +1104,29 @@ extern DXCALL int SetUseOldVolumeCalcFlag(int volumeFlag);
 
 // - Loads a sound file, returning a playable handle.
 // WAV files are loaded whole, OGG files are streamed.
-extern DXCALL int LoadSoundMem(const DXCHAR *filename,
-                               int bufferNum = 3, int unionHandle = -1);
+extern DXCALL int LoadSoundMemW(const wchar_t *filename,
+                                int bufferNum = 3, int unionHandle = -1);
+extern DXCALL int LoadSoundMemA(const char *filename,
+                                int bufferNum = 3, int unionHandle = -1);
+DXUNICALL_WRAP(LoadSoundMem,
+               (const TCHAR *filename, int bufferNum = 3, int unionHandle = -1),
+               (filename, bufferNum, unionHandle))
+
 // - Loads two sound files, an intro segment and then a second segment.
 // If this is played with DX_PLAYTYPE_LOP, only the second part will loop.
-extern DXCALL int LoadSoundMem2(const DXCHAR *filename,
-                                const DXCHAR *filename2);
+extern DXCALL int LoadSoundMem2W(const wchar_t *filename,
+                                 const wchar_t *filename2);
+extern DXCALL int LoadSoundMem2A(const char *filename,
+                                 const char *filename2);
+DXUNICALL_WRAP(LoadSoundMem2,
+               (const TCHAR *filename, const TCHAR *filename2),
+               (filename, filename2))
 
 // - Deletes a sound handle.
-extern DXCALL int DeleteSoundMem(int soundID, int LogOutFlag = FALSE);
+extern DXCALL int DeleteSoundMem(int soundID, int LogOutFlag = DXFALSE);
 
 // - Deletes all sound handles.
-extern DXCALL int InitSoundMem(int LogOutFlag = FALSE);
+extern DXCALL int InitSoundMem(int LogOutFlag = DXFALSE);
 
 // - Sets the data storage type for loaded sounds.
 // NOTICE: DxPortLib currently only supports DX_SOUNDDATATYPE_MEMNOPRESS.

--- a/include/DxLib_c.h
+++ b/include/DxLib_c.h
@@ -74,9 +74,17 @@ extern DXCALL void DxLib_EXT_SetOnlyWindowSize(int width, int height,
 /* ----------------------------------------------------------- DxFile.cpp */
 extern DXCALL int DxLib_EXT_FileRead_SetCharSet(int charset);
 
-extern DXCALL int DxLib_FileRead_open(const DXCHAR *filename, int ASync);
+extern DXCALL int DxLib_FileRead_openW(const wchar_t *filename, int ASync);
+extern DXCALL int DxLib_FileRead_openA(const char *filename, int ASync);
+DXUNICALL_WRAP(DxLib_FileRead_open, 
+               (const TCHAR *filename, int ASync),
+               (filename, ASync))
 
-extern DXCALL int64_t DxLib_FileRead_size(const DXCHAR *filename);
+extern DXCALL int64_t DxLib_FileRead_sizeW(const wchar_t *filename);
+extern DXCALL int64_t DxLib_FileRead_sizeA(const char *filename);
+DXUNICALL_WRAP(DxLib_FileRead_size,
+               (const TCHAR *filename),
+               (filename))
 
 extern DXCALL int DxLib_FileRead_close(int fileHandle);
 
@@ -89,27 +97,74 @@ extern DXCALL int DxLib_FileRead_read(void *data, int size, int fileHandle);
 
 extern DXCALL int DxLib_FileRead_eof(int fileHandle);
 
-extern DXCALL int DxLib_FileRead_gets(DXCHAR *buffer,
+extern DXCALL int DxLib_FileRead_getsW(wchar_t *buffer,
                                       int bufferSize, int fileHandle);
-extern DXCALL DXCHAR DxLib_FileRead_getc(int fileHandle);
-extern DXCALL int DxLib_FileRead_scanf(int fileHandle,
-                                       const DXCHAR *format, ...);
+extern DXCALL int DxLib_FileRead_getsA(char *buffer,
+                                      int bufferSize, int fileHandle);
+DXUNICALL_WRAP(DxLib_FileRead_gets,
+               (TCHAR *buffer, int bufferSize, int fileHandle),
+               (buffer, bufferSize, fileHandle))
+
+extern DXCALL wchar_t DxLib_FileRead_getcW(int fileHandle);
+extern DXCALL char DxLib_FileRead_getcA(int fileHandle);
+static DXINLINE TCHAR DxLib_FileRead_getc(int fileHandle) {
+    return DXUNICALL(DxLib_FileRead_getc)(fileHandle);
+}
+
+extern DXCALL int DxLib_FileRead_vscanfW(int fileHandle,
+                                         const wchar_t *format, va_list args);
+extern DXCALL int DxLib_FileRead_vscanfA(int fileHandle,
+                                         const char *format, va_list args);
+DXUNICALL_WRAP(DxLib_FileRead_vscanf,
+        (int fileHandle, const TCHAR *format, va_list args),
+        (fileHandle, format, args))
+
+extern DXCALL int DxLib_FileRead_scanfW(int fileHandle,
+                                        const wchar_t *format, ...);
+extern DXCALL int DxLib_FileRead_scanfA(int fileHandle,
+                                        const char *format, ...);
+DXUNICALL_VA_WRAPTO(
+    DxLib_FileRead_scanf, (int fileHandle, const TCHAR *format, ...),
+    DxLib_FileRead_vscanf, (fileHandle, format, args), format)
 
 /* -------------------------------------------------------- DxArchive.cpp */
 extern DXCALL int DxLib_SetUseDXArchiveFlag(int flag);
 
-extern DXCALL int DxLib_SetDXArchiveKeyString(const DXCHAR *keyString);
+extern DXCALL int DxLib_SetDXArchiveKeyStringW(const wchar_t *keyString);
+extern DXCALL int DxLib_SetDXArchiveKeyStringA(const char *keyString);
+DXUNICALL_WRAP(DxLib_SetDXArchiveKeyString,
+               (const TCHAR *keyString), (keyString))
 
-extern DXCALL int DxLib_SetDXArchiveExtension(const DXCHAR *extension);
+extern DXCALL int DxLib_SetDXArchiveExtensionW(const wchar_t *extension);
+extern DXCALL int DxLib_SetDXArchiveExtensionA(const char *extension);
+DXUNICALL_WRAP(DxLib_SetDXArchiveExtension,
+               (const TCHAR *extension), (extension))
 
 extern DXCALL int DxLib_SetDXArchivePriority(int priority);
 
-extern DXCALL int DxLib_DXArchivePreLoad(const DXCHAR *dxaFilename,
-                                         int async);
-extern DXCALL int DxLib_DXArchiveCheckIdle(const DXCHAR *dxaFilename);
-extern DXCALL int DxLib_DXArchiveRelease(const DXCHAR *dxaFilename);
-extern DXCALL int DxLib_DXArchiveCheckFile(const DXCHAR *dxaFilename,
-                                           const DXCHAR *filename);
+extern DXCALL int DxLib_DXArchivePreLoadW(const wchar_t *dxaFilename, int async);
+extern DXCALL int DxLib_DXArchivePreLoadA(const char *dxaFilename, int async);
+DXUNICALL_WRAP(DxLib_DXArchivePreLoad,
+               (const TCHAR *dxaFilename, int async),
+               (dxaFilename, async))
+
+extern DXCALL int DxLib_DXArchiveCheckIdleW(const wchar_t *dxaFilename);
+extern DXCALL int DxLib_DXArchiveCheckIdleA(const char *dxaFilename);
+DXUNICALL_WRAP(DxLib_DXArchiveCheckIdle,
+               (const TCHAR *dxaFilename), (dxaFilename))
+
+extern DXCALL int DxLib_DXArchiveReleaseW(const wchar_t *dxaFilename);
+extern DXCALL int DxLib_DXArchiveReleaseA(const char *dxaFilename);
+DXUNICALL_WRAP(DxLib_DXArchiveRelease,
+               (const TCHAR *dxaFilename), (dxaFilename))
+
+extern DXCALL int DxLib_DXArchiveCheckFileW(const wchar_t *dxaFilename,
+                                            const wchar_t *filename);
+extern DXCALL int DxLib_DXArchiveCheckFileA(const char *dxaFilename,
+                                            const char *filename);
+DXUNICALL_WRAP(DxLib_DXArchiveCheckFile,
+               (const TCHAR *dxaFilename, const TCHAR *filename),
+               (dxaFilename, filename))
 
 /* ---------------------------------------------------------- DxInput.cpp */
 #ifndef DX_NON_INPUT
@@ -153,8 +208,13 @@ extern DXCALL int DxLib_SetGraphMode(int width, int height,
                                      int bitDepth, int FPS);
 extern DXCALL int DxLib_SetWindowSizeChangeEnableFlag(int windowResizeFlag,
                                                       int fitScreen);
-extern DXCALL int DxLib_SetWindowText(const DXCHAR *windowName);
-extern DXCALL int DxLib_SetMainWindowText(const DXCHAR *windowName);
+extern DXCALL int DxLib_SetWindowTextW(const wchar_t *windowName);
+extern DXCALL int DxLib_SetWindowTextA(const char *windowName);
+DXUNICALL_WRAP(DxLib_SetWindowText, (const TCHAR *windowName),
+               (windowName))
+DXUNICALL_WRAPTO(DxLib_SetMainWindowText, (const TCHAR *windowName),
+                 DxLib_SetWindowText, (windowName))
+
 extern DXCALL int DxLib_ScreenFlip();
 extern DXCALL int DxLib_ChangeWindowMode(int fullscreenFlag);
 extern DXCALL int DxLib_GetWindowModeFlag();
@@ -165,38 +225,97 @@ extern DXCALL int DxLib_SetMouseDispFlag(int flag);
 extern DXCALL int DxLib_GetMouseDispFlag();
 extern DXCALL int DxLib_SetWaitVSyncFlag(int flag);
 extern DXCALL int DxLib_GetWaitVSyncFlag();
-extern DXCALL int DxLib_EXT_SetIconImageFile(const DXCHAR *filename);
 extern DXCALL int DxLib_SetAlwaysRunFlag(int flag);
 extern DXCALL int DxLib_GetAlwaysRunFlag();
 extern DXCALL int DxLib_GetWindowActiveFlag();
 extern DXCALL int DxLib_GetActiveFlag();
 
-extern DXCALL int DxLib_EXT_MessageBoxError(const DXCHAR *title,
-                                            const DXCHAR *text);
-extern DXCALL int DxLib_EXT_MessageBoxYesNo(const DXCHAR *title,
-                                            const DXCHAR *text,
-                                            const DXCHAR *button1,
-                                            const DXCHAR *button2);
+extern DXCALL int DxLib_EXT_SetIconImageFileW(const wchar_t *filename);
+extern DXCALL int DxLib_EXT_SetIconImageFileA(const char *filename);
+DXUNICALL_WRAP(DxLib_EXT_SetIconImageFile,
+               (const TCHAR *filename), (filename))
+
+extern DXCALL int DxLib_EXT_MessageBoxErrorA(const char *title,
+                                             const char *text);
+extern DXCALL int DxLib_EXT_MessageBoxErrorW(const wchar_t *title,
+                                             const wchar_t *text);
+DXUNICALL_WRAP(DxLib_EXT_MessageBoxError,
+               (const TCHAR *title, const TCHAR *text), (title, text))
+
+extern DXCALL int DxLib_EXT_MessageBoxYesNoW(const wchar_t *title,
+                                             const wchar_t *text,
+                                             const wchar_t *button1,
+                                             const wchar_t *button2);
+extern DXCALL int DxLib_EXT_MessageBoxYesNoA(const char *title,
+                                             const char *text,
+                                             const char *button1,
+                                             const char *button2);
+DXUNICALL_WRAP(DxLib_EXT_MessageBoxYesNo,
+               (const TCHAR *title, const TCHAR *text,
+                const TCHAR *button1, const TCHAR *button2),
+               (title, text, button1, button2))
 
 /* ------------------------------------------------------- DxGraphics.cpp */
 extern DXCALL int DxLib_MakeScreen(int width, int height,
                                    int hasAlphaChannel);
 
-extern DXCALL int DxLib_LoadGraph(const DXCHAR *name, int notUse3DFlag);
+extern DXCALL int DxLib_LoadGraphW(const wchar_t *name, int notUse3DFlag);
+extern DXCALL int DxLib_LoadGraphA(const char *name, int notUse3DFlag);
+DXUNICALL_WRAP(DxLib_LoadGraph,
+               (const TCHAR *name, int NotUse3DFlag),
+               (name, NotUse3DFlag))
 
-extern DXCALL int DxLib_LoadReverseGraph(const DXCHAR *name, int notUse3DFlag);
-extern DXCALL int DxLib_LoadDivGraph(
-                          const DXCHAR *filename, int graphCount,
+extern DXCALL int DxLib_LoadReverseGraphW(const wchar_t *name, int notUse3DFlag);
+extern DXCALL int DxLib_LoadReverseGraphA(const char *name, int notUse3DFlag);
+DXUNICALL_WRAP(DxLib_LoadReverseGraph,
+               (const TCHAR *name, int NotUse3DFlag),
+               (name, NotUse3DFlag))
+
+extern DXCALL int DxLib_LoadDivGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf, int notUse3DFlag);
-extern DXCALL int DxLib_LoadDivBmpGraph(
-                          const DXCHAR *filename, int graphCount,
+extern DXCALL int DxLib_LoadDivGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf, int notUse3DFlag);
+DXUNICALL_WRAP(DxLib_LoadDivGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int notUse3DFlag),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, notUse3DFlag))
+
+extern DXCALL int DxLib_LoadDivBmpGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf, int textureFlag, int flipFlag);
-extern DXCALL int DxLib_LoadReverseDivGraph(
-                          const DXCHAR *filename, int graphCount,
+extern DXCALL int DxLib_LoadDivBmpGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf, int textureFlag, int flipFlag);
+DXUNICALL_WRAP(DxLib_LoadDivBmpGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int textureFlag, int flipFlag),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, textureFlag, flipFlag))
+
+extern DXCALL int DxLib_LoadReverseDivGraphW(
+                          const wchar_t *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf, int notUse3DFlag);
+extern DXCALL int DxLib_LoadReverseDivGraphA(
+                          const char *filename, int graphCount,
+                          int xCount, int yCount, int xSize, int ySize,
+                          int *handleBuf, int notUse3DFlag);
+DXUNICALL_WRAP(DxLib_LoadReverseDivGraph,
+               (const TCHAR *filename, int graphCount,
+                int xCount, int yCount, int xSize, int ySize,
+                int *handleBuf, int notUse3DFlag),
+               (filename, graphCount, xCount, yCount,
+                xSize, ySize, handleBuf, notUse3DFlag))
+
 extern DXCALL int DxLib_DeleteGraph(int graphID, int LogOutFlag);
 extern DXCALL int DxLib_DeleteSharingGraph(int graphID);
 extern DXCALL int DxLib_InitGraph(int LogOutFlag);
@@ -379,96 +498,225 @@ extern DXCALL int DxLib_SetBackgroundColor(int red, int green, int blue);
 extern DXCALL int DxLib_ClearDrawScreen(const RECT *clearRect);
 extern DXCALL int DxLib_ClsDrawScreen();
 
-extern DXCALL int DxLib_SaveDrawScreen(int x1, int y1, int x2, int y2,
-                                       const DXCHAR *filename, int saveType,
-                                       int jpegQuality, int jpegSample2x1,
-                                       int pngCompressionLevel);
-extern DXCALL int DxLib_SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                                            const DXCHAR *filename);
-extern DXCALL int DxLib_SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                                             const DXCHAR *filename,
-                                             int quality, int sample2x1);
-extern DXCALL int DxLib_SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                                            const DXCHAR *filename,
-                                            int compressionLevel);
+extern DXCALL int DxLib_SaveDrawScreenA(int x1, int y1, int x2, int y2,
+                                        const char *filename, int saveType,
+                                        int jpegQuality, int jpegSample2x1,
+                                        int pngCompressionLevel);
+extern DXCALL int DxLib_SaveDrawScreenW(int x1, int y1, int x2, int y2,
+                                        const wchar_t *filename, int saveType,
+                                        int jpegQuality, int jpegSample2x1,
+                                        int pngCompressionLevel);
+DXUNICALL_WRAP(DxLib_SaveDrawScreen,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename,
+                int saveType, int jpegQuality, int jpegSample2x1,
+                int pngCompressionLevel),
+               (x1, y1, x2, y2, filename, saveType,
+                jpegQuality, jpegSample2x1, pngCompressionLevel))
+
+extern DXCALL int DxLib_SaveDrawScreenToBMPA(int x1, int y1, int x2, int y2,
+                                             const char *filename);
+extern DXCALL int DxLib_SaveDrawScreenToBMPW(int x1, int y1, int x2, int y2,
+                                             const wchar_t *filename);
+DXUNICALL_WRAP(DxLib_SaveDrawScreenToBMP,
+               (int x1, int y1, int x2, int y2, const TCHAR *filename),
+               (x1, y1, x2, y2, filename))
+
+extern DXCALL int DxLib_SaveDrawScreenToJPEGA(int x1, int y1, int x2, int y2,
+                                              const char *filename,
+                                              int quality, int sample2x1);
+extern DXCALL int DxLib_SaveDrawScreenToJPEGW(int x1, int y1, int x2, int y2,
+                                              const wchar_t *filename,
+                                              int quality, int sample2x1);
+DXUNICALL_WRAP(DxLib_SaveDrawScreenToJPEG,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename, int quality, int sample2x1),
+               (x1, y1, x2, y2, filename, quality, sample2x1))
+
+extern DXCALL int DxLib_SaveDrawScreenToPNGA(int x1, int y1, int x2, int y2,
+                                             const char *filename,
+                                             int compressionLevel);
+extern DXCALL int DxLib_SaveDrawScreenToPNGW(int x1, int y1, int x2, int y2,
+                                             const wchar_t *filename,
+                                             int compressionLevel);
+DXUNICALL_WRAP(DxLib_SaveDrawScreenToPNG,
+               (int x1, int y1, int x2, int y2,
+                const TCHAR *filename, int compressionLevel),
+               (x1, y1, x2, y2, filename, compressionLevel))
 
 extern DXCALL DXCOLOR DxLib_GetColor(int red, int green, int blue);
 
 /* ----------------------------------------------------------- DxFont.cpp */
 #ifndef DX_NON_FONT
 
-extern DXCALL int DxLib_EXT_MapFontFileToName(const DXCHAR *filename,
-                                              const DXCHAR *fontname,
-                                              int thickness,
-                                              int boldFlag,
-                                              double exRateX,
-                                              double exRateY
-                                             );
+extern DXCALL int DxLib_EXT_MapFontFileToNameW(const wchar_t *filename,
+                                               const wchar_t *fontname,
+                                               int thickness,
+                                               int boldFlag,
+                                               double exRateX,
+                                               double exRateY);
+extern DXCALL int DxLib_EXT_MapFontFileToNameA(const char *filename,
+                                               const char *fontname,
+                                               int thickness,
+                                               int boldFlag,
+                                               double exRateX,
+                                               double exRateY);
+DXUNICALL_WRAP(DxLib_EXT_MapFontFileToName,
+               (const TCHAR *filename, const TCHAR *fontname,
+                int thickness, int boldFlag,
+                double exRateX, double exRateY),
+               (filename, fontname, thickness, boldFlag,
+                exRateX, exRateY))
+
 extern DXCALL int DxLib_EXT_InitFontMappings();
 
 /* Handle font functions */
-extern DXCALL int DxLib_DrawStringToHandle(int x, int y,
-                                           const DXCHAR *string,
-                                           DXCOLOR color, int fontHandle,
-                                           DXCOLOR edgeColor,
-                                           int VerticalFlag);
-extern DXCALL int DxLib_DrawFormatStringToHandle(int x, int y,
-                                                 DXCOLOR color,
-                                                 int fontHandle,
-                                                 const DXCHAR *formatString,
-                                                 ...);
-extern DXCALL int DxLib_DrawExtendStringToHandle(int x, int y,
-                                                 double ExRateX,
-                                                 double ExRateY,
-                                                 const DXCHAR *string,
-                                                 DXCOLOR color,
-                                                 int fontHandle,
-                                                 DXCOLOR edgeColor,
-                                                 int VerticalFlag);
-extern DXCALL int DxLib_DrawExtendFormatStringToHandle(
-                                                 int x, int y,
-                                                 double ExRateX,
-                                                 double ExRateY,
-                                                 DXCOLOR color,
-                                                 int fontHandle,
-                                                 const DXCHAR *formatString,
-                                                 ...);
+extern DXCALL int DxLib_DrawStringToHandleW(int x, int y,
+                                            const wchar_t *string,
+                                            DXCOLOR color, int fontHandle,
+                                            DXCOLOR edgeColor,
+                                            int VerticalFlag);
+extern DXCALL int DxLib_DrawStringToHandleA(int x, int y,
+                                            const char *string,
+                                            DXCOLOR color, int fontHandle,
+                                            DXCOLOR edgeColor,
+                                            int VerticalFlag);
+DXUNICALL_WRAP(DxLib_DrawStringToHandle,
+               (int x, int y, const TCHAR *string,
+                DXCOLOR color, int fontHandle,
+                DXCOLOR edgeColor,
+                int VerticalFlag),
+               (x, y, string, color, fontHandle,
+                edgeColor, VerticalFlag))
 
-extern DXCALL int DxLib_GetDrawStringWidthToHandle(const DXCHAR *string,
-                                                   int strLen,
-                                                   int fontHandle,
-                                                   int VerticalFlag);
-extern DXCALL int DxLib_GetDrawFormatStringWidthToHandle(
-                                                   int fontHandle,
-                                                   const DXCHAR *string,
-                                                   ...);
-extern DXCALL int DxLib_GetDrawExtendStringWidthToHandle(
-                                                   double ExRateX,
-                                                   const DXCHAR *string,
-                                                   int strLen,
-                                                   int fontHandle,
-                                                   int VerticalFlag);
-extern DXCALL int DxLib_GetDrawExtendFormatStringWidthToHandle(
-                                                   double ExRateX,
-                                                   int fontHandle,
-                                                   const DXCHAR *string,
-                                                   ...);
+extern DXCALL int DxLib_DrawFormatVStringToHandleW(int x, int y,
+                                                  DXCOLOR color,
+                                                  int fontHandle,
+                                                  const wchar_t *formatString,
+                                                  va_list args);
+extern DXCALL int DxLib_DrawFormatVStringToHandleA(int x, int y,
+                                                  DXCOLOR color,
+                                                  int fontHandle,
+                                                  const char *formatString,
+                                                  va_list args);
+DXUNICALL_WRAP(DxLib_DrawFormatVStringToHandle,
+               (int x, int y, DXCOLOR color, int fontHandle,
+                const TCHAR *formatString, va_list args),
+               (x, y, color, fontHandle, formatString, args))
+
+DXUNICALL_VA_WRAPTO(DxLib_DrawFormatStringToHandle,
+                    (int x, int y, DXCOLOR color,
+                     int fontHandle,
+                     const TCHAR *formatString, ...),
+                    DxLib_DrawFormatVStringToHandle,
+                    (x, y, color, fontHandle, formatString, args),
+                    formatString)
+
+extern DXCALL int DxLib_DrawExtendStringToHandleW(int x, int y,
+                    double ExRateX, double ExRateY,
+                    const wchar_t *string, DXCOLOR color,
+                    int fontHandle, DXCOLOR edgeColor, int VerticalFlag);
+extern DXCALL int DxLib_DrawExtendStringToHandleA(int x, int y,
+                    double ExRateX, double ExRateY,
+                    const char *string, DXCOLOR color,
+                    int fontHandle, DXCOLOR edgeColor, int VerticalFlag);
+DXUNICALL_WRAP(DxLib_DrawExtendStringToHandle,
+               (double ExRateX, double ExRateY, int x, int y,
+                const TCHAR *string, DXCOLOR color, int fontHandle,
+                DXCOLOR edgeColor, int VerticalFlag),
+               (ExRateX, ExRateY, x, y, string,
+                color, fontHandle, edgeColor, VerticalFlag))
+
+extern DXCALL int DxLib_DrawExtendFormatVStringToHandleA(
+                    int x, int y, double ExRateX, double ExRateY, DXCOLOR color,
+                    int fontHandle, const char *formatString, va_list args);
+extern DXCALL int DxLib_DrawExtendFormatVStringToHandleW(
+                    int x, int y, double ExRateX, double ExRateY, DXCOLOR color,
+                    int fontHandle, const wchar_t *formatString, va_list args);
+DXUNICALL_VA_WRAPTO(DxLib_DrawExtendFormatStringToHandle,
+                    (double ExRateX, double ExRateY, int x, int y,
+                     DXCOLOR color, int fontHandle, const TCHAR *formatString, ...),
+                    DxLib_DrawExtendFormatVStringToHandle,
+                    (ExRateX, ExRateY, x, y,
+                     color, fontHandle, formatString, args),
+                    formatString)
+
+extern DXCALL int DxLib_GetDrawStringWidthToHandleA(
+                    const char *string, int strLen,
+                    int fontHandle, int VerticalFlag);
+extern DXCALL int DxLib_GetDrawStringWidthToHandleW(
+                    const wchar_t *string, int strLen,
+                    int fontHandle, int VerticalFlag);
+DXUNICALL_WRAP(DxLib_GetDrawStringWidthToHandle,
+                (const TCHAR *string, int strLen, int fontHandle,
+                 int VerticalFlag),
+                (string, strLen, fontHandle, VerticalFlag))
+
+extern DXCALL int DxLib_GetDrawFormatVStringWidthToHandleW(
+                    int fontHandle, const wchar_t *string, va_list args);
+extern DXCALL int DxLib_GetDrawFormatVStringWidthToHandleA(
+                    int fontHandle, const char *string, va_list args);
+DXUNICALL_VA_WRAPTO(DxLib_GetDrawFormatStringWidthToHandle,
+                    (int fontHandle, const TCHAR *string, ...),
+                    DxLib_GetDrawFormatVStringWidthToHandle,
+                    (fontHandle, string, args),
+                    string)
+
+extern DXCALL int DxLib_GetDrawExtendStringWidthToHandleW(
+                    double ExRateX, const wchar_t *string,
+                    int strLen, int fontHandle, int VerticalFlag);
+extern DXCALL int DxLib_GetDrawExtendStringWidthToHandleA(
+                    double ExRateX, const char *string,
+                    int strLen, int fontHandle, int VerticalFlag);
+DXUNICALL_WRAP(DxLib_GetDrawExtendStringWidthToHandle,
+               (double ExRateX, const TCHAR *string,
+                int strLen, int fontHandle, int VerticalFlag),
+               (ExRateX, string, strLen, fontHandle, VerticalFlag))
+
+extern DXCALL int DxLib_GetDrawExtendFormatVStringWidthToHandleW(
+                    double ExRateX, int fontHandle,
+                    const wchar_t *string, va_list args);
+extern DXCALL int DxLib_GetDrawExtendFormatVStringWidthToHandleA(
+                    double ExRateX, int fontHandle,
+                    const char *string, va_list args);
+DXUNICALL_VA_WRAPTO(DxLib_GetDrawExtendFormatStringWidthToHandle,
+                    (double ExRateX, int fontHandle, const TCHAR *string, ...),
+                    DxLib_GetDrawExtendFormatVStringWidthToHandle,
+                    (ExRateX, fontHandle, string, args),
+                    string)
 
 extern DXCALL int DxLib_GetFontSizeToHandle(int fontHandle);
-extern DXCALL int DxLib_GetFontCharInfo(int fontHandle,
-                                        const DXCHAR *string,
-                                        int *xPos, int *yPos,
-                                        int *advanceX,
-                                        int *width, int *height);
+extern DXCALL int DxLib_GetFontCharInfoA(
+                    int fontHandle, const char *string,
+                    int *xPos, int *yPos, int *advanceX,
+                    int *width, int *height);
+extern DXCALL int DxLib_GetFontCharInfoW(
+                    int fontHandle, const wchar_t *string,
+                    int *xPos, int *yPos, int *advanceX,
+                    int *width, int *height);
+DXUNICALL_WRAP(DxLib_GetFontCharInfo,
+               (int fontHandle, const TCHAR *string,
+                int *xPos, int *yPos, int *advanceX,
+                int *width, int *height),
+               (fontHandle, string, xPos, yPos, advanceX, width, height))
+
 extern DXCALL int DxLib_SetFontSpaceToHandle(int fontSpacing,
                                              int fontHandle);
 
-extern DXCALL int DxLib_CreateFontToHandle(const DXCHAR *fontname,
-                                           int size, int thickness,
-                                           int fontType, int charset,
-                                           int edgeSize, int italic,
-                                           int handle
-                                           );
+extern DXCALL int DxLib_CreateFontToHandleA(
+                    const char *fontname, int size, int thickness,
+                    int fontType, int charset, int edgeSize, int italic,
+                    int handle);
+extern DXCALL int DxLib_CreateFontToHandleW(
+                    const wchar_t *fontname, int size, int thickness,
+                    int fontType, int charset, int edgeSize, int italic,
+                    int handle);
+DXUNICALL_WRAP(DxLib_CreateFontToHandle,
+               (const TCHAR *fontname, int size, int thickness,
+                int fontType, int charset, int edgeSize,
+                int italic, int handle),
+               (fontname, size, thickness, fontType, charset, edgeSize,
+                italic, handle))
 extern DXCALL int DxLib_DeleteFontToHandle(int handle);
 extern DXCALL int DxLib_CheckFontHandleValid(int fontHandle);
 extern DXCALL int DxLib_SetFontLostFlag(int fontHandle, int *lostFlag);
@@ -476,42 +724,75 @@ extern DXCALL int DxLib_SetFontLostFlag(int fontHandle, int *lostFlag);
 extern DXCALL int DxLib_InitFontToHandle();
 
 /* "Default" font functions */
-extern DXCALL int DxLib_DrawString(int x, int y,
-                                   const DXCHAR *string,
-                                   DXCOLOR color,
-                                   DXCOLOR edgeColor
-                                  );
-extern DXCALL int DxLib_DrawFormatString(int x, int y, DXCOLOR color,
-                                         const DXCHAR *formatString, ...);
-extern DXCALL int DxLib_DrawExtendString(int x, int y,
-                                         double ExRateX, double ExRateY,
-                                         const DXCHAR *string, DXCOLOR color,
-                                         DXCOLOR edgeColor);
-extern DXCALL int DxLib_DrawExtendFormatString(
-                                         int x, int y,
-                                         double ExRateX, double ExRateY,
-                                         DXCOLOR color,
-                                         const DXCHAR *formatString, ...);
-extern DXCALL int DxLib_GetDrawStringWidth(const DXCHAR *string,
-                                           int strLen, int VerticalFlag);
-extern DXCALL int DxLib_GetDrawFormatStringWidth(const DXCHAR *string, ...);
-extern DXCALL int DxLib_GetDrawExtendStringWidth(double ExRateX,
-                                                 const DXCHAR *string,
-                                                 int strLen, int VerticalFlag);
-extern DXCALL int DxLib_GetDrawExtendFormatStringWidth(
-                                                 double ExRateX,
-                                                 const DXCHAR *string, ...);
+extern DXCALL int DxLib_GetDefaultFontHandle();
 
-extern DXCALL int DxLib_ChangeFont(const DXCHAR *string, int charSet);
+DXUNICALL_WRAPTO(DxLib_DrawString, 
+                 (int x, int y, const TCHAR *string,
+                  DXCOLOR color, DXCOLOR edgeColor),
+                 DxLib_DrawStringToHandle,
+                 (x, y, string, color, DxLib_GetDefaultFontHandle(),
+                  edgeColor, FALSE))
+DXUNICALL_VA_WRAPTO(DxLib_DrawFormatString, 
+                    (int x, int y, DXCOLOR color, const TCHAR *formatString, ...),
+                    DxLib_DrawFormatVStringToHandle,
+                    (x, y, color, DxLib_GetDefaultFontHandle(), formatString, args),
+                    formatString)
+
+DXUNICALL_WRAPTO(DxLib_DrawExtendString,
+                 (int x, int y, double ExRateX, double ExRateY,
+                  const TCHAR *string, DXCOLOR color, DXCOLOR edgeColor),
+                 DxLib_DrawExtendStringToHandle,
+                 (ExRateX, ExRateY, x, y, string, color,
+                  DxLib_GetDefaultFontHandle(), edgeColor, FALSE))
+DXUNICALL_VA_WRAPTO(DxLib_DrawExtendFormatString,
+                    (int x, int y, double ExRateX, double ExRateY,
+                     DXCOLOR color, const TCHAR *formatString, ...),
+                    DxLib_DrawExtendFormatVStringToHandle,
+                    (ExRateX, ExRateY, x, y, color,
+                     DxLib_GetDefaultFontHandle(), formatString, args),
+                    formatString)
+
+DXUNICALL_WRAPTO(DxLib_GetDrawStringWidth,
+                 (const TCHAR *string, int strLen, int VerticalFlag),
+                 DxLib_GetDrawStringWidthToHandle,
+                 (string, strLen, DxLib_GetDefaultFontHandle(), VerticalFlag))
+DXUNICALL_VA_WRAPTO(DxLib_GetDrawFormatStringWidth,
+                    (const TCHAR *string, ...),
+                    DxLib_GetDrawFormatVStringWidthToHandle,
+                    (DxLib_GetDefaultFontHandle(), string, args),
+                    string)
+
+DXUNICALL_WRAPTO(DxLib_GetDrawExtendStringWidth,
+                 (double ExRateX, const TCHAR *string,
+                  int strLen, int VerticalFlag),
+                 DxLib_GetDrawExtendStringWidthToHandle,
+                 (ExRateX, string, strLen,
+                  DxLib_GetDefaultFontHandle(), VerticalFlag))
+
+DXUNICALL_VA_WRAPTO(DxLib_GetDrawExtendFormatStringWidth,
+                    (double ExRateX, const TCHAR *string, ...),
+                    DxLib_GetDrawExtendFormatVStringWidthToHandle,
+                    (ExRateX, DxLib_GetDefaultFontHandle(), string, args),
+                    string)
+
+extern DXCALL int DxLib_ChangeFontW(const wchar_t *fontName, int charSet);
+extern DXCALL int DxLib_ChangeFontA(const char *fontName, int charSet);
+DXUNICALL_WRAP(DxLib_ChangeFont,
+               (const TCHAR *fontName, int charSet),
+               (fontName, charSet))
+
 extern DXCALL int DxLib_ChangeFontType(int fontType);
 extern DXCALL int DxLib_SetFontSize(int fontSize);
 extern DXCALL int DxLib_GetFontSize();
 extern DXCALL int DxLib_SetFontThickness(int fontThickness);
 extern DXCALL int DxLib_SetFontSpace(int fontSpace);
-extern DXCALL int DxLib_SetDefaultFontState(const DXCHAR *fontName,
-                                            int fontSize,
-                                            int fontThickness);
-extern DXCALL int DxLib_GetDefaultFontHandle();
+extern DXCALL int DxLib_SetDefaultFontStateW(
+                const wchar_t *fontName, int fontSize, int fontThickness);
+extern DXCALL int DxLib_SetDefaultFontStateA(
+                const char *fontName, int fontSize, int fontThickness);
+DXUNICALL_WRAP(DxLib_SetDefaultFontState,
+               (const TCHAR *fontName, int fontSize, int fontThickness),
+               (fontName, fontSize, fontThickness))
 
 extern DXCALL int DxLib_SetFontCacheUsePremulAlphaFlag(int flag);
 extern DXCALL int DxLib_GetFontCacheUsePremulAlphaFlag();
@@ -531,11 +812,22 @@ extern DXCALL int DxLib_SetVolumeSoundMem(int volume, int soundID);
 extern DXCALL int DxLib_ChangeVolumeSoundMem(int volume, int soundID);
 extern DXCALL int DxLib_SetUseOldVolumeCalcFlag(int volumeFlag);
 
-extern DXCALL int DxLib_LoadSoundMem(const DXCHAR *filename,
-                                     int bufferNum,
-                                     int unionHandle);
-extern DXCALL int DxLib_LoadSoundMem2(const DXCHAR *filename,
-                                      const DXCHAR *filename2);
+extern DXCALL int DxLib_LoadSoundMemW(
+                const wchar_t *filename, int bufferNum, int unionHandle);
+extern DXCALL int DxLib_LoadSoundMemA(
+                const char *filename, int bufferNum, int unionHandle);
+DXUNICALL_WRAP(DxLib_LoadSoundMem,
+               (const TCHAR *filename, int bufferNum, int unionHandle),
+               (filename, bufferNum, unionHandle))
+
+extern DXCALL int DxLib_LoadSoundMem2W(
+                const wchar_t *filename, const wchar_t *filename2);
+extern DXCALL int DxLib_LoadSoundMem2A(
+                const char *filename, const char *filename2);
+DXUNICALL_WRAP(DxLib_LoadSoundMem2,
+               (const TCHAR *filename, const TCHAR *filename2),
+               (filename, filename2))
+
 extern DXCALL int DxLib_DeleteSoundMem(int soundID,
                                        int LogOutFlag);
 

--- a/include/Luna.h
+++ b/include/Luna.h
@@ -554,7 +554,7 @@ public:
     static LUNACALL Bool WaitForMsgLoop(Bool isFullActive = false);
     static LUNACALL void SyncFrame();
     
-    static LUNACALL void SetApplicationName(const DXCHAR *name);
+    static LUNACALL void SetApplicationName(const char *name);
     static LUNACALL void SetScreenInfo(Sint32 width, Sint32 height,
                              Bool isWindow);
     static LUNACALL void SetFrameRate(Sint32 frameRate);
@@ -581,11 +581,11 @@ public:
     // If you want to use anything other than UTF8, use this.
     static LUNACALL void EXTSetUseCharset(int dxCharset);
     
-    static LUNACALL void EXTGetSaveFolder(DXCHAR *buffer, int bufferLength,
-                             const DXCHAR *org, const DXCHAR *app,
+    static LUNACALL void EXTGetSaveFolder(char *buffer, int bufferLength,
+                             const char *org, const char *app,
                              int destEncoding);
-    static LUNACALL int EXTConvertText(DXCHAR *buffer, int bufferLength,
-                            const DXCHAR *string,
+    static LUNACALL int EXTConvertText(char *buffer, int bufferLength,
+                            const char *string,
                             int destEncoding, int srcEncoding);
     
     static LUNACALL void EXTSetFullscreenDesktop(bool flag);
@@ -594,7 +594,7 @@ public:
                                               bool isFullscreen,
                                               bool isFullscreenDesktop);
     
-    static LUNACALL void EXTSetWindowIconFromFile(const DXCHAR *filename);
+    static LUNACALL void EXTSetWindowIconFromFile(const char *filename);
     static LUNACALL void EXTSetVSync(bool vsyncEnabled);
     
     // Supplied by the application.
@@ -621,9 +621,9 @@ public:
 class LunaFile {
 public:
     static LUNACALL void SetRootPath(Uint32 Priority,
-                                     const DXCHAR *pRootPath,
-                                     const DXCHAR *pPackFile);
-    static LUNACALL FILEDATA *FileOpen(const DXCHAR *pFile,
+                                     const char *pRootPath,
+                                     const char *pPackFile);
+    static LUNACALL FILEDATA *FileOpen(const char *pFile,
                                        Bool ReadOnly = false);
     
     static LUNACALL Uint32 FileGetSize( FILEDATA *pFile );
@@ -673,11 +673,11 @@ public:
 /* ------------------------------------------------------ LunaTexture.cpp */
 class LunaTexture {
 public:
-    static LUNACALL LTEXTURE CreateFromFile(const DXCHAR *pFileName,
+    static LUNACALL LTEXTURE CreateFromFile(const char *pFileName,
                               eSurfaceFormat format,
                               D3DCOLOR keyColor = COLORKEY_DISABLE);
-    static LUNACALL LTEXTURE CreateFromLAG(const DXCHAR *pFileName,
-                              const DXCHAR *pDataName,
+    static LUNACALL LTEXTURE CreateFromLAG(const char *pFileName,
+                              const char *pDataName,
                               eSurfaceFormat Format );
     static LUNACALL void Release(LTEXTURE texture);
 };
@@ -712,19 +712,19 @@ public:
 /* --------------------------------------------------- LunaFontSprite.cpp */
 class LunaFontSprite {
 public:
-    static LUNACALL LFONTSPRITE CreateFromFile(const DXCHAR *pFileName,
-                                 const DXCHAR *pExt, Bool IsAlpha, Uint32 Num,
+    static LUNACALL LFONTSPRITE CreateFromFile(const char *pFileName,
+                                 const char *pExt, Bool IsAlpha, Uint32 Num,
                                  Bool IsSortZ = false,
                                  eSurfaceFormat Format = FORMAT_TEXTURE_2D);
     static LUNACALL void Release(LFONTSPRITE lFontSpr);
-    static LUNACALL void DrawString(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+    static LUNACALL void DrawString(LFONTSPRITE lFontSpr, const char *pStr,
                           Sint32 Px, Sint32 Py, Float Pz, D3DCOLOR Color);
-    static LUNACALL void DrawStringP(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+    static LUNACALL void DrawStringP(LFONTSPRITE lFontSpr, const char *pStr,
                           Sint32 Px, Sint32 Py, Float Pz, D3DCOLOR Color);
     static LUNACALL void ResetBuffer(LFONTSPRITE lFontSpr, Sint32 Space = 0);
     static LUNACALL void UpdateBuffer(LFONTSPRITE lFontSpr);
     static LUNACALL void Rendering(LFONTSPRITE lFontSpr);
-    static LUNACALL Bool GetWidth(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+    static LUNACALL Bool GetWidth(LFONTSPRITE lFontSpr, const char *pStr,
                          Sint32 *pLeft, Sint32 *pCenter, Sint32 *pRight);
 };
 
@@ -752,7 +752,7 @@ public:
 /* -------------------------------------------------------- LunaSound.cpp */
 class LunaSound {
 public:
-    static LUNACALL LSOUND CreateFromFile(const DXCHAR *filename,
+    static LUNACALL LSOUND CreateFromFile(const char *filename,
                             bool IsNoStop, bool IsAyame = true,
                             bool IsHardware = false, Uint32 Layer = 1);
     static LUNACALL Bool IsPlay(LSOUND lSnd, Uint32 Layer = 0);
@@ -767,7 +767,7 @@ public:
     static LUNACALL void SetPan(LSOUND lSnd, Float fParam,
                                 Uint32 Layer = 0);
     static LUNACALL void SetMax(Uint32 Max);
-    static LUNACALL void SetAyamePath(const DXCHAR *pPath);
+    static LUNACALL void SetAyamePath(const char *pPath);
     
     static LUNACALL void EXTSetLoopSamples(LSOUND lSnd,
                              Uint64 loopTarget, Uint64 loopPoint);

--- a/src/DxLib/DxFile.c
+++ b/src/DxLib/DxFile.c
@@ -13,7 +13,7 @@
   1. The origin of this software must not be misrepresented; you must not
      claim that you wrote the original software. If you use this software
      in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required. 
+     appreciated but is not required.
   2. Altered source versions must be plainly marked as such, and must not be
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
@@ -538,7 +538,7 @@ int Dx_FileRead_vscanfA(int fileHandle, const char *format, va_list args) {
         return 0;
     }
     
-    return PL_Text_Vsscanf(buffer, 4096, g_DxUseCharSet, format, args);
+    return PL_Text_Vsscanf(buffer, g_DxUseCharSet, format, args);
 }
 int Dx_FileRead_vscanfW(int fileHandle, const wchar_t *format, va_list args) {
     wchar_t buffer[4096];
@@ -549,7 +549,7 @@ int Dx_FileRead_vscanfW(int fileHandle, const wchar_t *format, va_list args) {
         return 0;
     }
     
-    return PL_Text_Wvsscanf(buffer, 4096, g_DxUseCharSet, format, args);
+    return PL_Text_Wvsscanf(buffer, g_DxUseCharSet, format, args);
 }
 
 int Dx_File_OpenRead(const char *filename) {

--- a/src/DxLib/DxFile.c
+++ b/src/DxLib/DxFile.c
@@ -483,7 +483,7 @@ int Dx_FileRead_getsW(wchar_t *buffer, int bufferSize, int fileHandle) {
         return -1;
     }
     
-    // TODO: support and skip 0xfeff header.
+    /* TODO: support and skip 0xfeff header. */
     
     while (remaining > 0 && (ch = Dx_FileRead_getWholeChar(fileHandle)) != -1) {
         if (ch == '\r') {

--- a/src/DxLib/DxGraph.c
+++ b/src/DxLib/DxGraph.c
@@ -135,7 +135,7 @@ int Dx_Graph_MakeScreen(int width, int height, int hasAlphaChannel) {
     return graphID;
 }
 
-int Dx_Graph_Load(const DXCHAR *filename, int flipFlag) {
+int Dx_Graph_Load(const char *filename, int flipFlag) {
     int surfaceID = PL_Surface_Load(filename);
     int graphID;
     
@@ -260,7 +260,7 @@ int Dx_Graph_Derivation(int x, int y, int w, int h, int srcGraphID) {
     return s_AllocateGraphID(srcGraph->textureRefID, rect, srcGraphID);
 }
 
-int Dx_Graph_LoadDiv(const DXCHAR *filename, int graphCount,
+int Dx_Graph_LoadDiv(const char *filename, int graphCount,
                      int xCount, int yCount, int xSize, int ySize,
                      int *handleBuf, int textureFlag, int flipFlag) {
     int graphID = Dx_Graph_Load(filename, flipFlag);

--- a/src/DxLib/DxInternal.h
+++ b/src/DxLib/DxInternal.h
@@ -32,38 +32,41 @@
 extern "C" {
 #endif
 
+/* ---------------------------------------------------------------Globals */
+extern int g_DxUseCharSet;
+
 /* --------------------------------------------------------------- File.c */
-extern SDL_RWops *Dx_File_OpenArchiveStream(const DXCHAR *filename);
-extern SDL_RWops *Dx_File_OpenDirectStream(const DXCHAR *filename);
-extern SDL_RWops *Dx_File_OpenStream(const DXCHAR *filename);
+extern SDL_RWops *Dx_File_OpenArchiveStream(const char *filename);
+extern SDL_RWops *Dx_File_OpenDirectStream(const char *filename);
+extern SDL_RWops *Dx_File_OpenStream(const char *filename);
 
-extern int Dx_File_ReadFile(const DXCHAR *filename, unsigned char **dData, unsigned int *dSize);
+extern int Dx_File_ReadFile(const char *filename, unsigned char **dData, unsigned int *dSize);
 
-extern int Dx_File_SetDXArchiveKeyString(const DXCHAR *keyString);
-extern int Dx_File_SetDXArchiveExtension(const DXCHAR *extension);
+extern int Dx_File_SetDXArchiveKeyString(const char *keyString);
+extern int Dx_File_SetDXArchiveExtension(const char *extension);
 
 extern int Dx_File_SetUseDXArchiveFlag(int flag);
 extern int Dx_File_GetUseDXArchiveFlag();
 extern int Dx_File_SetDXArchivePriority(int flag);
 
-extern int Dx_File_DXArchivePreLoad(const DXCHAR *dxaFilename, int async);
-extern int Dx_File_DXArchiveCheckIdle(const DXCHAR *dxaFilename);
-extern int Dx_File_DXArchiveRelease(const DXCHAR *dxaFilename);
-extern int Dx_File_DXArchiveCheckFile(const DXCHAR *dxaFilename, const DXCHAR *filename);
+extern int Dx_File_DXArchivePreLoad(const char *dxaFilename, int async);
+extern int Dx_File_DXArchiveCheckIdle(const char *dxaFilename);
+extern int Dx_File_DXArchiveRelease(const char *dxaFilename);
+extern int Dx_File_DXArchiveCheckFile(const char *dxaFilename, const char *filename);
 
 extern int PLEXT_FileRead_SetCharSet(int charset);
 
-extern int Dx_FileRead_open(const DXCHAR *filename);
-extern int64_t Dx_FileRead_size(const DXCHAR *filename);
+extern int Dx_FileRead_open(const char *filename);
+extern int64_t Dx_FileRead_size(const char *filename);
 extern int Dx_FileRead_close(int fileHandle);
 extern int64_t Dx_FileRead_tell(int fileHandle);
 extern int Dx_FileRead_seek(int fileHandle, int64_t position, int origin);
 extern int Dx_FileRead_read(void *data, int size, int fileHandle);
 extern int Dx_FileRead_eof(int fileHandle);
 
-extern int Dx_FileRead_gets(DXCHAR *buffer, int bufferSize, int fileHandle);
-extern DXCHAR Dx_FileRead_getc(int fileHandle);
-extern int Dx_FileRead_vscanf(int fileHandle, const DXCHAR *format, va_list args);
+extern int Dx_FileRead_getsA(char *buffer, int bufferSize, int fileHandle);
+extern char Dx_FileRead_getcA(int fileHandle);
+extern int Dx_FileRead_vscanfA(int fileHandle, const char *format, va_list args);
 
 extern int Dx_File_Init();
 extern int Dx_File_End();
@@ -226,10 +229,76 @@ extern int Dx_Draw_SetDrawScreen(int drawScreen);
 extern int Dx_Draw_GetDrawScreen();
 extern int Dx_Draw_ResetDrawScreen();
 
+/* -------------------------------------------------------------- Font.c */
+/* Handle font functions */
+extern int Dx_Font_DrawStringToHandle(int x, int y, const DXCHAR *string,
+                                      DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
+extern int Dx_Font_DrawFormatStringToHandle(int x, int y, DXCOLOR color, int fontHandle,
+                                            const DXCHAR *string, va_list args);
+extern int Dx_Font_DrawExtendStringToHandle(int x, int y, double ExRateX, double ExRateY,
+                                            const DXCHAR *string,
+                                            DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
+extern int Dx_Font_DrawExtendFormatStringToHandle(int x, int y, double ExRateX, double ExRateY,
+                                                  DXCOLOR color, int fontHandle,
+                                                  const DXCHAR *string, va_list args);
+
+extern int Dx_Font_GetDrawStringWidthToHandle(const DXCHAR *string, int strLen, int fontHandle);
+extern int Dx_Font_GetDrawFormatStringWidthToHandle(int fontHandle, const DXCHAR *string, va_list args);
+extern int Dx_Font_GetDrawExtendStringWidthToHandle(double ExRateX, const DXCHAR *string, int strLen, int fontHandle);
+extern int Dx_Font_GetDrawExtendFormatStringWidthToHandle(double ExRateX, int fontHandle, const DXCHAR *string, va_list args);
+
+extern int Dx_Font_GetFontSizeToHandle(int fontHandle);
+extern int Dx_Font_GetFontCharInfo(int fontHandle, const DXCHAR *string,
+                              int *xPos, int *yPos, int *advanceX, int *width, int *height);
+extern int Dx_Font_SetFontSpaceToHandle(int fontSpacing, int fontHandle);
+
+extern int Dx_Font_CreateFontToHandle(const DXCHAR *fontname,
+                                 int size, int thickness, int fontType, int charset,
+                                 int edgeSize, int italic
+                                );
+extern int Dx_Font_DeleteFontToHandle(int handle);
+extern int Dx_Font_CheckFontHandleValid(int fontHandle);
+extern int Dx_Font_SetFontLostFlag(int fontHandle, int *lostFlag);
+
+extern int Dx_Font_InitFontToHandle();
+
+/* "Default" font functions */
+extern int Dx_Font_DrawString(int x, int y, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
+extern int Dx_Font_DrawFormatString(int x, int y, DXCOLOR color, const DXCHAR *string, va_list args);
+extern int Dx_Font_DrawExtendString(int x, int y, double ExRateX, double ExRateY, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
+extern int Dx_Font_DrawExtendFormatString(int x, int y, double ExRateX, double ExRateY, DXCOLOR color, const DXCHAR *string, va_list args);
+extern int Dx_Font_GetDrawStringWidth(const DXCHAR *string, int strLen);
+extern int Dx_Font_GetDrawFormatStringWidth(const DXCHAR *string, va_list args);
+extern int Dx_Font_GetDrawExtendStringWidth(double ExRateX, const DXCHAR *string, int strLen);
+extern int Dx_Font_GetDrawExtendFormatStringWidth(double ExRateX, const DXCHAR *string, va_list args);
+
+extern int Dx_Font_ChangeFont(const DXCHAR *string, int charSet);
+extern int Dx_Font_ChangeFontType(int fontType);
+extern int Dx_Font_SetFontSize(int fontSize);
+extern int Dx_Font_GetFontSize();
+extern int Dx_Font_SetFontThickness(int fontThickness);
+extern int Dx_Font_SetFontSpace(int fontSpace);
+extern int Dx_Font_SetDefaultFontState(const DXCHAR *fontName, int fontSize, int fontThickness);
+extern int Dx_Font_GetDefaultFontHandle();
+
+/* Font mappings and upkeep. */
+extern int PLEXT_Font_MapFontFileToName(const DXCHAR *filename,
+                                   const DXCHAR *fontname,
+                                   int thickness, int boldFlag,
+                                   double exRateX, double exRateY
+                                  );
+extern int PLEXT_Font_InitFontMappings();
+
+extern void Dx_Font_Init();
+extern void Dx_Font_End();
+
+extern int Dx_Font_SetFontCacheUsePremulAlphaFlag(int flag);
+extern int Dx_Font_GetFontCacheUsePremulAlphaFlag();
+
 /* ------------------------------------------------------------- Graph.c */
 extern int Dx_Graph_MakeScreen(int width, int height, int hasAlphaChannel);
-extern int Dx_Graph_Load(const DXCHAR *filename, int flipFlag);
-extern int Dx_Graph_LoadDiv(const DXCHAR *filename, int graphCount,
+extern int Dx_Graph_Load(const char *filename, int flipFlag);
+extern int Dx_Graph_LoadDiv(const char *filename, int graphCount,
                             int xCount, int yCount, int xSize, int ySize,
                             int *handleBuf, int textureFlag, int flipFlag);
 extern int Dx_Graph_CreateFromSurface(int surfaceID);

--- a/src/DxLib/DxInternal.h
+++ b/src/DxLib/DxInternal.h
@@ -65,8 +65,11 @@ extern int Dx_FileRead_read(void *data, int size, int fileHandle);
 extern int Dx_FileRead_eof(int fileHandle);
 
 extern int Dx_FileRead_getsA(char *buffer, int bufferSize, int fileHandle);
+extern int Dx_FileRead_getsW(wchar_t *buffer, int bufferSize, int fileHandle);
 extern char Dx_FileRead_getcA(int fileHandle);
+extern wchar_t Dx_FileRead_getcW(int fileHandle);
 extern int Dx_FileRead_vscanfA(int fileHandle, const char *format, va_list args);
+extern int Dx_FileRead_vscanfW(int fileHandle, const wchar_t *format, va_list args);
 
 extern int Dx_File_Init();
 extern int Dx_File_End();
@@ -80,16 +83,16 @@ extern int Dx_File_End();
 typedef struct DXArchive DXArchive;
 
 extern void DXA_CloseArchive(DXArchive *archive);
-extern DXArchive *DXA_OpenArchive(const DXCHAR *filename, const char *keyString);
+extern DXArchive *DXA_OpenArchive(const char *filename, const char *keyString);
 extern int DXA_PreloadArchive(DXArchive *archive);
 
 extern void DXA_SetArchiveKey(DXArchive *archive, const char *keystring);
 extern void DXA_SetArchiveKeyRaw(DXArchive *archive, const unsigned char *key);
 
-extern int DXA_ReadFile(DXArchive *archive, const DXCHAR *filename, unsigned char **dDest, unsigned int *dSize);
-extern int DXA_TestFile(DXArchive *archive, const DXCHAR *filename);
+extern int DXA_ReadFile(DXArchive *archive, const char *filename, unsigned char **dDest, unsigned int *dSize);
+extern int DXA_TestFile(DXArchive *archive, const char *filename);
 
-extern SDL_RWops *DXA_OpenStream(DXArchive *archive, const DXCHAR *filename);
+extern SDL_RWops *DXA_OpenStream(DXArchive *archive, const char *filename);
 
 #else /* #ifndef DX_NOT_DXA */
 
@@ -231,28 +234,34 @@ extern int Dx_Draw_ResetDrawScreen();
 
 /* -------------------------------------------------------------- Font.c */
 /* Handle font functions */
-extern int Dx_Font_DrawStringToHandle(int x, int y, const DXCHAR *string,
-                                      DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
-extern int Dx_Font_DrawFormatStringToHandle(int x, int y, DXCOLOR color, int fontHandle,
-                                            const DXCHAR *string, va_list args);
-extern int Dx_Font_DrawExtendStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                                            const DXCHAR *string,
-                                            DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
-extern int Dx_Font_DrawExtendFormatStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                                                  DXCOLOR color, int fontHandle,
-                                                  const DXCHAR *string, va_list args);
+extern int Dx_Font_DrawStringA(int x, int y, double ExRateX, double ExRateY,
+                               const char *string,
+                               DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                               int VerticalFlag);
+extern int Dx_Font_DrawStringW(int x, int y, double ExRateX, double ExRateY,
+                               const wchar_t *string,
+                               DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                               int VerticalFlag);
+extern int Dx_Font_DrawVStringFA(int x, int y, double ExRateX, double ExRateY,
+                                 DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                                 int VerticalFlag,
+                                 const char *format, va_list args);
+extern int Dx_Font_DrawVStringFW(int x, int y, double ExRateX, double ExRateY,
+                                 DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                                 int VerticalFlag,
+                                 const wchar_t *format, va_list args);
 
-extern int Dx_Font_GetDrawStringWidthToHandle(const DXCHAR *string, int strLen, int fontHandle);
-extern int Dx_Font_GetDrawFormatStringWidthToHandle(int fontHandle, const DXCHAR *string, va_list args);
-extern int Dx_Font_GetDrawExtendStringWidthToHandle(double ExRateX, const DXCHAR *string, int strLen, int fontHandle);
-extern int Dx_Font_GetDrawExtendFormatStringWidthToHandle(double ExRateX, int fontHandle, const DXCHAR *string, va_list args);
+extern int Dx_Font_GetStringWidthA(const char *string, int strLen, int fontHandle);
+extern int Dx_Font_GetStringWidthW(const wchar_t *string, int strLen, int fontHandle);
+extern int Dx_Font_GetVStringWidthFA(int strLen, int fontHandle, const char *format, va_list args);
+extern int Dx_Font_GetVStringWidthFW(int strLen, int fontHandle, const wchar_t *format, va_list args);
 
 extern int Dx_Font_GetFontSizeToHandle(int fontHandle);
-extern int Dx_Font_GetFontCharInfo(int fontHandle, const DXCHAR *string,
+extern int Dx_Font_GetFontCharInfo(int fontHandle, const char *string,
                               int *xPos, int *yPos, int *advanceX, int *width, int *height);
 extern int Dx_Font_SetFontSpaceToHandle(int fontSpacing, int fontHandle);
 
-extern int Dx_Font_CreateFontToHandle(const DXCHAR *fontname,
+extern int Dx_Font_CreateFontToHandle(const char *fontname,
                                  int size, int thickness, int fontType, int charset,
                                  int edgeSize, int italic
                                 );
@@ -263,27 +272,18 @@ extern int Dx_Font_SetFontLostFlag(int fontHandle, int *lostFlag);
 extern int Dx_Font_InitFontToHandle();
 
 /* "Default" font functions */
-extern int Dx_Font_DrawString(int x, int y, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
-extern int Dx_Font_DrawFormatString(int x, int y, DXCOLOR color, const DXCHAR *string, va_list args);
-extern int Dx_Font_DrawExtendString(int x, int y, double ExRateX, double ExRateY, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
-extern int Dx_Font_DrawExtendFormatString(int x, int y, double ExRateX, double ExRateY, DXCOLOR color, const DXCHAR *string, va_list args);
-extern int Dx_Font_GetDrawStringWidth(const DXCHAR *string, int strLen);
-extern int Dx_Font_GetDrawFormatStringWidth(const DXCHAR *string, va_list args);
-extern int Dx_Font_GetDrawExtendStringWidth(double ExRateX, const DXCHAR *string, int strLen);
-extern int Dx_Font_GetDrawExtendFormatStringWidth(double ExRateX, const DXCHAR *string, va_list args);
-
-extern int Dx_Font_ChangeFont(const DXCHAR *string, int charSet);
+extern int Dx_Font_ChangeFont(const char *string, int charSet);
 extern int Dx_Font_ChangeFontType(int fontType);
 extern int Dx_Font_SetFontSize(int fontSize);
 extern int Dx_Font_GetFontSize();
 extern int Dx_Font_SetFontThickness(int fontThickness);
 extern int Dx_Font_SetFontSpace(int fontSpace);
-extern int Dx_Font_SetDefaultFontState(const DXCHAR *fontName, int fontSize, int fontThickness);
+extern int Dx_Font_SetDefaultFontState(const char *fontName, int fontSize, int fontThickness);
 extern int Dx_Font_GetDefaultFontHandle();
 
 /* Font mappings and upkeep. */
-extern int PLEXT_Font_MapFontFileToName(const DXCHAR *filename,
-                                   const DXCHAR *fontname,
+extern int PLEXT_Font_MapFontFileToName(const char *filename,
+                                   const char *fontname,
                                    int thickness, int boldFlag,
                                    double exRateX, double exRateY
                                   );

--- a/src/DxLib/DxLib.cpp
+++ b/src/DxLib/DxLib.cpp
@@ -137,7 +137,7 @@ int FileRead_scanf(int fileHandle, const DXCHAR *format, ...) {
     int retval;
     
     va_start(args, format);
-    retval = Dx_FileRead_vscanf(fileHandle, format, args);
+    retval = Dx_FileRead_vscanfA(fileHandle, format, args);
     va_end(args);
     
     return retval;
@@ -700,7 +700,7 @@ int DrawFormatStringToHandle(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_DrawFormatStringToHandle(x, y, color, fontHandle, formatString, args);
+    retval = ::Dx_Font_DrawFormatStringToHandle(x, y, color, fontHandle, formatString, args);
     va_end(args);
     return retval;
 }
@@ -719,7 +719,7 @@ int DrawExtendFormatStringToHandle(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_DrawExtendFormatStringToHandle(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
+    retval = ::Dx_Font_DrawExtendFormatStringToHandle(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
     va_end(args);
     return retval;
 }
@@ -734,7 +734,7 @@ int GetDrawFormatStringWidthToHandle(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_GetDrawFormatStringWidthToHandle(fontHandle, formatString, args);
+    retval = ::Dx_Font_GetDrawFormatStringWidthToHandle(fontHandle, formatString, args);
     va_end(args);
     return retval;
 }
@@ -748,7 +748,7 @@ int GetDrawExtendFormatStringWidthToHandle(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_GetDrawExtendFormatStringWidthToHandle(ExRateX, fontHandle, formatString, args);
+    retval = ::Dx_Font_GetDrawExtendFormatStringWidthToHandle(ExRateX, fontHandle, formatString, args);
     va_end(args);
     return retval;
 }
@@ -798,7 +798,7 @@ int DrawFormatString(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_DrawFormatString(x, y, color, formatString, args);
+    retval = ::Dx_Font_DrawFormatString(x, y, color, formatString, args);
     va_end(args);
     return retval;
 }
@@ -814,7 +814,7 @@ int DrawExtendFormatString(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_DrawExtendFormatString(x, y, ExRateX, ExRateY, color, formatString, args);
+    retval = ::Dx_Font_DrawExtendFormatString(x, y, ExRateX, ExRateY, color, formatString, args);
     va_end(args);
     return retval;
 }
@@ -827,7 +827,7 @@ int GetDrawFormatStringWidth(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_GetDrawFormatStringWidth(formatString, args);
+    retval = ::Dx_Font_GetDrawFormatStringWidth(formatString, args);
     va_end(args);
     return retval;
 }
@@ -840,7 +840,7 @@ int GetDrawExtendFormatStringWidth(
     va_list args;
     int retval;
     va_start(args, formatString);
-    retval = ::PL_Font_GetDrawExtendFormatStringWidth(ExRateX, formatString, args);
+    retval = ::Dx_Font_GetDrawExtendFormatStringWidth(ExRateX, formatString, args);
     va_end(args);
     return retval;
 }

--- a/src/DxLib/DxLib.cpp
+++ b/src/DxLib/DxLib.cpp
@@ -98,12 +98,18 @@ int EXT_FileRead_SetCharSet(int charset) {
     return ::DxLib_EXT_FileRead_SetCharSet(charset);
 }
 
-int FileRead_open(const DXCHAR *filename, int ASync) {
-    return ::DxLib_FileRead_open(filename, ASync);
+int FileRead_openA(const char *filename, int ASync) {
+    return ::DxLib_FileRead_openA(filename, ASync);
+}
+int FileRead_openW(const wchar_t *filename, int ASync) {
+    return ::DxLib_FileRead_openW(filename, ASync);
 }
 
-int64_t FileRead_size(const DXCHAR *filename) {
-    return ::DxLib_FileRead_size(filename);
+int64_t FileRead_sizeA(const char *filename) {
+    return ::DxLib_FileRead_sizeA(filename);
+}
+int64_t FileRead_sizeW(const wchar_t *filename) {
+    return ::DxLib_FileRead_sizeW(filename);
 }
 
 int FileRead_close(int fileHandle) {
@@ -126,47 +132,70 @@ int FileRead_eof(int fileHandle) {
     return ::DxLib_FileRead_eof(fileHandle);
 }
 
-int FileRead_gets(DXCHAR *buffer, int bufferSize, int fileHandle) {
-    return ::DxLib_FileRead_gets(buffer, bufferSize, fileHandle);
+int FileRead_getsA(char *buffer, int bufferSize, int fileHandle) {
+    return ::DxLib_FileRead_getsA(buffer, bufferSize, fileHandle);
 }
-DXCHAR FileRead_getc(int fileHandle) {
-    return ::DxLib_FileRead_getc(fileHandle);
+int FileRead_getsW(wchar_t *buffer, int bufferSize, int fileHandle) {
+    return ::DxLib_FileRead_getsW(buffer, bufferSize, fileHandle);
 }
-int FileRead_scanf(int fileHandle, const DXCHAR *format, ...) {
-    va_list args;
-    int retval;
-    
-    va_start(args, format);
-    retval = Dx_FileRead_vscanfA(fileHandle, format, args);
-    va_end(args);
-    
-    return retval;
+
+char FileRead_getcA(int fileHandle) {
+    return ::DxLib_FileRead_getcA(fileHandle);
+}
+wchar_t FileRead_getcW(int fileHandle) {
+    return ::DxLib_FileRead_getcW(fileHandle);
+}
+
+int FileRead_vscanfA(int fileHandle, const char *format, va_list args) {
+    return ::DxLib_FileRead_vscanfA(fileHandle, format, args);
+}
+int FileRead_vscanfW(int fileHandle, const wchar_t *format, va_list args) {
+    return ::DxLib_FileRead_vscanfW(fileHandle, format, args);
 }
 
 // ---------------------------------------------------- DxArchive.cpp
 int SetUseDXArchiveFlag(int flag) {
     return ::DxLib_SetUseDXArchiveFlag(flag);
 }
-int SetDXArchiveKeyString(const DXCHAR *keyString) {
-    return ::DxLib_SetDXArchiveKeyString(keyString);
+int SetDXArchiveKeyStringW(const wchar_t *keyString) {
+    return ::DxLib_SetDXArchiveKeyStringW(keyString);
 }
-int SetDXArchiveExtension(const DXCHAR *extension) {
+int SetDXArchiveKeyStringA(const char *keyString) {
+    return ::DxLib_SetDXArchiveKeyStringA(keyString);
+}
+int SetDXArchiveExtensionW(const wchar_t *extension) {
+    return ::DxLib_SetDXArchiveExtensionW(extension);
+}
+int SetDXArchiveExtensionA(const char *extension) {
     return ::DxLib_SetDXArchiveExtension(extension);
 }
+
 int SetDXArchivePriority(int priority) {
     return ::DxLib_SetDXArchivePriority(priority);
 }
-int DXArchivePreLoad(const DXCHAR *dxaFilename, int async) {
-    return ::DxLib_DXArchivePreLoad(dxaFilename, async);
+int DXArchivePreLoadA(const char *dxaFilename, int async) {
+    return ::DxLib_DXArchivePreLoadA(dxaFilename, async);
 }
-int DXArchiveCheckIdle(const DXCHAR *dxaFilename) {
-    return ::DxLib_DXArchiveCheckIdle(dxaFilename);
+int DXArchivePreLoadW(const wchar_t *dxaFilename, int async) {
+    return ::DxLib_DXArchivePreLoadW(dxaFilename, async);
 }
-int DXArchiveRelease(const DXCHAR *dxaFilename) {
-    return ::DxLib_DXArchiveRelease(dxaFilename);
+int DXArchiveCheckIdleA(const char *dxaFilename) {
+    return ::DxLib_DXArchiveCheckIdleA(dxaFilename);
 }
-int DXArchiveCheckFile(const DXCHAR *dxaFilename, const DXCHAR *filename) {
-    return ::DxLib_DXArchiveCheckFile(dxaFilename, filename);
+int DXArchiveCheckIdleW(const wchar_t *dxaFilename) {
+    return ::DxLib_DXArchiveCheckIdleW(dxaFilename);
+}
+int DXArchiveReleaseA(const char *dxaFilename) {
+    return ::DxLib_DXArchiveReleaseA(dxaFilename);
+}
+int DXArchiveReleaseW(const wchar_t *dxaFilename) {
+    return ::DxLib_DXArchiveReleaseW(dxaFilename);
+}
+int DXArchiveCheckFileA(const char *dxaFilename, const char *filename) {
+    return ::DxLib_DXArchiveCheckFileA(dxaFilename, filename);
+}
+int DXArchiveCheckFileW(const wchar_t *dxaFilename, const wchar_t *filename) {
+    return ::DxLib_DXArchiveCheckFileW(dxaFilename, filename);
 }
 
 // ---------------------------------------------------- DxInput.cpp
@@ -252,12 +281,13 @@ int SetWindowSizeChangeEnableFlag(int windowResizeFlag, int fitScreen) {
 #  undef SetWindowText
 #endif
 
-int SetWindowText(const DXCHAR *windowName) {
-    return ::DxLib_SetWindowText(windowName);
+int SetWindowTextA(const char *windowName) {
+    return ::DxLib_SetWindowTextA(windowName);
 }
-int SetMainWindowText(const DXCHAR *windowName) {
-    return ::DxLib_SetMainWindowText(windowName);
+int SetWindowTextW(const wchar_t *windowName) {
+    return ::DxLib_SetWindowTextW(windowName);
 }
+
 int ScreenFlip() {
     return ::DxLib_ScreenFlip();
 }
@@ -290,8 +320,11 @@ int SetMouseDispFlag(int flag) {
 int GetMouseDispFlag() {
     return ::DxLib_GetMouseDispFlag();
 }
-int EXT_SetIconImageFile(const DXCHAR *filename) {
-    return ::DxLib_EXT_SetIconImageFile(filename);
+int EXT_SetIconImageFileA(const char *filename) {
+    return ::DxLib_EXT_SetIconImageFileA(filename);
+}
+int EXT_SetIconImageFileW(const wchar_t *filename) {
+    return ::DxLib_EXT_SetIconImageFileW(filename);
 }
 int SetAlwaysRunFlag(int flag) {
     return ::DxLib_SetAlwaysRunFlag(flag);
@@ -306,12 +339,19 @@ int GetActiveFlag() {
     return ::DxLib_GetActiveFlag();
 }
 
-int EXT_MessageBoxError(const DXCHAR *title, const DXCHAR *text) {
-    return ::DxLib_EXT_MessageBoxError(title, text);
+int EXT_MessageBoxErrorA(const char *title, const char *text) {
+    return ::DxLib_EXT_MessageBoxErrorA(title, text);
 }
-int EXT_MessageBoxYesNo(const DXCHAR *title, const DXCHAR *text,
-                        const DXCHAR *button1, const DXCHAR *button2) {
-    return ::DxLib_EXT_MessageBoxYesNo(title, text, button1, button2);
+int EXT_MessageBoxErrorW(const wchar_t *title, const wchar_t *text) {
+    return ::DxLib_EXT_MessageBoxErrorW(title, text);
+}
+int EXT_MessageBoxYesNoA(const char *title, const char *text,
+                         const char *button1, const char *button2) {
+    return ::DxLib_EXT_MessageBoxYesNoA(title, text, button1, button2);
+}
+int EXT_MessageBoxYesNoW(const wchar_t *title, const wchar_t *text,
+                         const wchar_t *button1, const wchar_t *button2) {
+    return ::DxLib_EXT_MessageBoxYesNoW(title, text, button1, button2);
 }
 
 // ---------------------------------------------------- DxGraphics.cpp
@@ -319,29 +359,54 @@ int EXT_MessageBoxYesNo(const DXCHAR *title, const DXCHAR *text,
 int MakeScreen(int width, int height, int hasAlphaChannel) {
     return ::DxLib_MakeScreen(width, height, hasAlphaChannel);
 }
-int LoadGraph(const DXCHAR *name, int notUse3DFlag) {
-    return ::DxLib_LoadGraph(name, notUse3DFlag);
+int LoadGraphA(const char *name, int notUse3DFlag) {
+    return ::DxLib_LoadGraphA(name, notUse3DFlag);
 }
-int LoadReverseGraph(const DXCHAR *name, int notUse3DFlag) {
-    return ::DxLib_LoadReverseGraph(name, notUse3DFlag);
+int LoadGraphW(const wchar_t *name, int notUse3DFlag) {
+    return ::DxLib_LoadGraphW(name, notUse3DFlag);
 }
-int LoadDivGraph(const DXCHAR *filename, int graphCount,
-                 int xCount, int yCount, int xSize, int ySize,
-                 int *handleBuf, int notUse3DFlag) {
-    return ::DxLib_LoadDivGraph(filename, graphCount, xCount, yCount,
+int LoadReverseGraphA(const char *name, int notUse3DFlag) {
+    return ::DxLib_LoadReverseGraphA(name, notUse3DFlag);
+}
+int LoadReverseGraphW(const wchar_t *name, int notUse3DFlag) {
+    return ::DxLib_LoadReverseGraphW(name, notUse3DFlag);
+}
+int LoadDivGraphA(const char *filename, int graphCount,
+                  int xCount, int yCount, int xSize, int ySize,
+                  int *handleBuf, int notUse3DFlag) {
+    return ::DxLib_LoadDivGraphA(filename, graphCount, xCount, yCount,
                                 xSize, ySize, handleBuf, notUse3DFlag);
 }
-int LoadDivBmpGraph(const DXCHAR *filename, int graphCount,
-                    int xCount, int yCount, int xSize, int ySize,
-                    int *handleBuf, int textureFlag, int flipFlag) {
-    return ::DxLib_LoadDivBmpGraph(filename, graphCount, xCount, yCount,
+int LoadDivGraphW(const wchar_t *filename, int graphCount,
+                  int xCount, int yCount, int xSize, int ySize,
+                  int *handleBuf, int notUse3DFlag) {
+    return ::DxLib_LoadDivGraphW(filename, graphCount, xCount, yCount,
+                                xSize, ySize, handleBuf, notUse3DFlag);
+}
+int LoadDivBmpGraphA(const char *filename, int graphCount,
+                     int xCount, int yCount, int xSize, int ySize,
+                     int *handleBuf, int textureFlag, int flipFlag) {
+    return ::DxLib_LoadDivBmpGraphA(filename, graphCount, xCount, yCount,
                              xSize, ySize, handleBuf,
                              textureFlag, flipFlag);
 }
-int LoadReverseDivGraph(const DXCHAR *filename, int graphCount,
-                              int xCount, int yCount, int xSize, int ySize,
-                              int *handleBuf, int notUse3DFlag) {
-    return ::DxLib_LoadReverseDivGraph(filename, graphCount, xCount, yCount,
+int LoadDivBmpGraphW(const wchar_t *filename, int graphCount,
+                     int xCount, int yCount, int xSize, int ySize,
+                     int *handleBuf, int textureFlag, int flipFlag) {
+    return ::DxLib_LoadDivBmpGraphW(filename, graphCount, xCount, yCount,
+                             xSize, ySize, handleBuf,
+                             textureFlag, flipFlag);
+}
+int LoadReverseDivGraphA(const char *filename, int graphCount,
+                         int xCount, int yCount, int xSize, int ySize,
+                         int *handleBuf, int notUse3DFlag) {
+    return ::DxLib_LoadReverseDivGraphA(filename, graphCount, xCount, yCount,
+                                       xSize, ySize, handleBuf, notUse3DFlag);
+}
+int LoadReverseDivGraphW(const wchar_t *filename, int graphCount,
+                         int xCount, int yCount, int xSize, int ySize,
+                         int *handleBuf, int notUse3DFlag) {
+    return ::DxLib_LoadReverseDivGraphW(filename, graphCount, xCount, yCount,
                                        xSize, ySize, handleBuf, notUse3DFlag);
 }
 int DeleteGraph(int graphID, int LogOutFlag) {
@@ -637,47 +702,74 @@ int ClsDrawScreen() {
     return ::DxLib_ClsDrawScreen();
 }
 
-int SaveDrawScreen(int x1, int y1, int x2, int y2,
-                   const DXCHAR *filename, int saveType,
-                   int jpegQuality, int jpegSample2x1,
-                   int pngCompressionLevel) {
-    return ::DxLib_SaveDrawScreen(x1, y1, x2, y2, filename,
+int SaveDrawScreenA(int x1, int y1, int x2, int y2,
+                    const char *filename, int saveType,
+                    int jpegQuality, int jpegSample2x1,
+                    int pngCompressionLevel) {
+    return ::DxLib_SaveDrawScreenA(x1, y1, x2, y2, filename,
                                   saveType, jpegQuality, jpegSample2x1,
                                   pngCompressionLevel);
 }
-int SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                        const DXCHAR *filename) {
-    return ::DxLib_SaveDrawScreenToBMP(x1, y1, x2, y2, filename);
+int SaveDrawScreenW(int x1, int y1, int x2, int y2,
+                    const wchar_t *filename, int saveType,
+                    int jpegQuality, int jpegSample2x1,
+                    int pngCompressionLevel) {
+    return ::DxLib_SaveDrawScreenW(x1, y1, x2, y2, filename,
+                                  saveType, jpegQuality, jpegSample2x1,
+                                  pngCompressionLevel);
 }
-int SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                               const DXCHAR *filename,
-                               int quality, int sample2x1) {
-    return ::DxLib_SaveDrawScreenToJPEG(x1, y1, x2, y2, filename,
+int SaveDrawScreenToBMPA(int x1, int y1, int x2, int y2,
+                        const char *filename) {
+    return ::DxLib_SaveDrawScreenToBMPA(x1, y1, x2, y2, filename);
+}
+int SaveDrawScreenToBMPW(int x1, int y1, int x2, int y2,
+                         const wchar_t *filename) {
+    return ::DxLib_SaveDrawScreenToBMPW(x1, y1, x2, y2, filename);
+}
+int SaveDrawScreenToJPEGA(int x1, int y1, int x2, int y2,
+                          const char *filename,
+                          int quality, int sample2x1) {
+    return ::DxLib_SaveDrawScreenToJPEGA(x1, y1, x2, y2, filename,
                                         quality, sample2x1);
 }
-int SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                              const DXCHAR *filename,
-                              int compressionLevel) {
-    return ::DxLib_SaveDrawScreenToPNG(x1, y1, x2, y2, filename,
+int SaveDrawScreenToJPEGW(int x1, int y1, int x2, int y2,
+                          const wchar_t *filename,
+                          int quality, int sample2x1) {
+    return ::DxLib_SaveDrawScreenToJPEGW(x1, y1, x2, y2, filename,
+                                        quality, sample2x1);
+}
+int SaveDrawScreenToPNGA(int x1, int y1, int x2, int y2,
+                         const char *filename,
+                         int compressionLevel) {
+    return ::DxLib_SaveDrawScreenToPNGA(x1, y1, x2, y2, filename,
                                        compressionLevel);
 }
-
-DXCOLOR GetColor(int red, int green, int blue) {
-    return red | (green << 8) | (blue << 16);
+int SaveDrawScreenToPNGW(int x1, int y1, int x2, int y2,
+                         const wchar_t *filename,
+                         int compressionLevel) {
+    return ::DxLib_SaveDrawScreenToPNGW(x1, y1, x2, y2, filename,
+                                       compressionLevel);
 }
 
 // ---------------------------------------------------- DxFont.cpp
 #ifndef DX_NON_FONT
 
-int EXT_MapFontFileToName(const DXCHAR *filename,
-                          const DXCHAR *fontname,
-                          int thickness,
-                          int boldFlag,
-                          double exRateX,
-                          double exRateY
-                         ) {
-    return ::DxLib_EXT_MapFontFileToName(filename,
-                                         fontname,
+int EXT_MapFontFileToNameA(
+        const char *filename, const char *fontname,
+        int thickness,int boldFlag,
+        double exRateX, double exRateY
+) {
+    return ::DxLib_EXT_MapFontFileToNameA(filename, fontname,
+                                         thickness, boldFlag,
+                                         exRateX, exRateY
+                                        );
+}
+int EXT_MapFontFileToNameW(
+        const wchar_t *filename, const wchar_t *fontname,
+        int thickness,int boldFlag,
+        double exRateX, double exRateY
+) {
+    return ::DxLib_EXT_MapFontFileToNameW(filename, fontname,
                                          thickness, boldFlag,
                                          exRateX, exRateY
                                         );
@@ -687,88 +779,125 @@ int EXT_InitFontMappings() {
 }
 
 /* Handle font functions */
-int DrawStringToHandle(int x, int y, const DXCHAR *text,
-                       DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
-                       int verticalFlag) {
-    return ::DxLib_DrawStringToHandle(x, y, text, color, fontHandle,
+int DrawStringToHandleA(int x, int y, const char *text,
+                        DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                        int verticalFlag) {
+    return ::DxLib_DrawStringToHandleA(x, y, text, color, fontHandle,
                                       edgeColor, verticalFlag);
 }
-int DrawFormatStringToHandle(
-    int x, int y, DXCOLOR color, int fontHandle,
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_DrawFormatStringToHandle(x, y, color, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+int DrawStringToHandleW(int x, int y, const wchar_t *text,
+                        DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                        int verticalFlag) {
+    return ::DxLib_DrawStringToHandleW(x, y, text, color, fontHandle,
+                                      edgeColor, verticalFlag);
 }
-int DrawExtendStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                             const DXCHAR *text,
+int DrawFormatVStringToHandleA(
+    int x, int y, DXCOLOR color, int fontHandle,
+    const char *formatString, va_list args
+) {
+    return ::DxLib_DrawFormatVStringToHandleA(x, y, color, fontHandle, formatString, args);
+}
+int DrawFormatVStringToHandleW(
+    int x, int y, DXCOLOR color, int fontHandle,
+    const wchar_t *formatString, va_list args
+) {
+    return ::DxLib_DrawFormatVStringToHandleW(x, y, color, fontHandle, formatString, args);
+}
+int DrawExtendStringToHandleA(int x, int y, double ExRateX, double ExRateY,
+                             const char *text,
                              DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
                              int VerticalFlag) {
-    return ::DxLib_DrawExtendStringToHandle(x, y, ExRateX, ExRateY, text, color, fontHandle,
+    return ::DxLib_DrawExtendStringToHandleA(x, y, ExRateX, ExRateY, text, color, fontHandle,
                                             edgeColor, VerticalFlag);
 }
-int DrawExtendFormatStringToHandle(
+int DrawExtendStringToHandleW(int x, int y, double ExRateX, double ExRateY,
+                             const wchar_t *text,
+                             DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                             int VerticalFlag) {
+    return ::DxLib_DrawExtendStringToHandleW(x, y, ExRateX, ExRateY, text, color, fontHandle,
+                                            edgeColor, VerticalFlag);
+}
+int DrawExtendFormatVStringToHandleA(
     int x, int y, double ExRateX, double ExRateY,
     DXCOLOR color, int fontHandle,
-    const DXCHAR *formatString, ...
+    const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_DrawExtendFormatStringToHandle(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return ::DxLib_DrawExtendFormatVStringToHandleA(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
+}
+int DrawExtendFormatVStringToHandleW(
+    int x, int y, double ExRateX, double ExRateY,
+    DXCOLOR color, int fontHandle,
+    const wchar_t *formatString, va_list args
+) {
+    return ::DxLib_DrawExtendFormatVStringToHandleW(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
 }
 
-int GetDrawStringWidthToHandle(const DXCHAR *string, int strLen, int fontHandle,
+int GetDrawStringWidthToHandleA(const char *string, int strLen, int fontHandle,
                                int VerticalFlag) {
-    return ::DxLib_GetDrawStringWidthToHandle(string, strLen, fontHandle, VerticalFlag);
+    return ::DxLib_GetDrawStringWidthToHandleA(string, strLen, fontHandle, VerticalFlag);
 }
-int GetDrawFormatStringWidthToHandle(
-    int fontHandle, const DXCHAR *formatString, ...
+int GetDrawStringWidthToHandleW(const wchar_t *string, int strLen, int fontHandle,
+                               int VerticalFlag) {
+    return ::DxLib_GetDrawStringWidthToHandleW(string, strLen, fontHandle, VerticalFlag);
+}
+int GetDrawFormatVStringWidthToHandleA(
+    int fontHandle, const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_GetDrawFormatStringWidthToHandle(fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return DxLib_GetDrawFormatVStringWidthToHandleA(fontHandle, formatString, args);
 }
-int GetDrawExtendStringWidthToHandle(double ExRateX, const DXCHAR *string, int strLen,
+int GetDrawFormatVStringWidthToHandleW(
+    int fontHandle, const wchar_t *formatString, va_list args
+) {
+    return DxLib_GetDrawFormatVStringWidthToHandleW(fontHandle, formatString, args);
+}
+int GetDrawExtendStringWidthToHandleA(double ExRateX, const char *string, int strLen,
                                      int fontHandle, int VerticalFlag) {
-    return ::DxLib_GetDrawExtendStringWidthToHandle(ExRateX, string, strLen, fontHandle, VerticalFlag);
+    return ::DxLib_GetDrawExtendStringWidthToHandleA(ExRateX, string, strLen, fontHandle, VerticalFlag);
 }
-int GetDrawExtendFormatStringWidthToHandle(
-    double ExRateX, int fontHandle, const DXCHAR *formatString, ...
+int GetDrawExtendStringWidthToHandleW(double ExRateX, const wchar_t *string, int strLen,
+                                     int fontHandle, int VerticalFlag) {
+    return ::DxLib_GetDrawExtendStringWidthToHandleW(ExRateX, string, strLen, fontHandle, VerticalFlag);
+}
+int GetDrawExtendFormatVStringWidthToHandleA(
+    double ExRateX, int fontHandle, const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_GetDrawExtendFormatStringWidthToHandle(ExRateX, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return ::DxLib_GetDrawExtendFormatVStringWidthToHandleA(ExRateX, fontHandle, formatString, args);
+}
+int GetDrawExtendFormatVStringWidthToHandleW(
+    double ExRateX, int fontHandle, const wchar_t *formatString, va_list args
+) {
+    return ::DxLib_GetDrawExtendFormatVStringWidthToHandleW(ExRateX, fontHandle, formatString, args);
 }
 
 int GetFontSizeToHandle(int fontHandle) {
     return ::DxLib_GetFontSizeToHandle(fontHandle);
 }
-int GetFontCharInfo(int fontHandle, const DXCHAR *string,
-                          int *xPos, int *yPos, int *advanceX,
-                          int *width, int *height) {
-    return ::DxLib_GetFontCharInfo(fontHandle, string, xPos, yPos, advanceX, width, height);
+int GetFontCharInfoA(int fontHandle, const char *string,
+                     int *xPos, int *yPos, int *advanceX,
+                     int *width, int *height) {
+    return ::DxLib_GetFontCharInfoA(fontHandle, string, xPos, yPos, advanceX, width, height);
+}
+int GetFontCharInfoW(int fontHandle, const wchar_t *string,
+                     int *xPos, int *yPos, int *advanceX,
+                     int *width, int *height) {
+    return ::DxLib_GetFontCharInfoW(fontHandle, string, xPos, yPos, advanceX, width, height);
 }
 int SetFontSpaceToHandle(int fontSpacing, int fontHandle) {
     return ::DxLib_SetFontSpaceToHandle(fontSpacing, fontHandle);
 }
 
-int CreateFontToHandle(const DXCHAR *fontname,
-                       int size, int thickness, int fontType, int charSet,
-                       int edgeSize, int Italic, int handle) {
-    return ::DxLib_CreateFontToHandle(
+int CreateFontToHandleA(const char *fontname,
+                        int size, int thickness, int fontType, int charSet,
+                        int edgeSize, int Italic, int handle) {
+    return ::DxLib_CreateFontToHandleA(
+        fontname, size, thickness, fontType, charSet,
+        edgeSize, Italic, handle
+    );
+}
+int CreateFontToHandleW(const wchar_t *fontname,
+                        int size, int thickness, int fontType, int charSet,
+                        int edgeSize, int Italic, int handle) {
+    return ::DxLib_CreateFontToHandleW(
         fontname, size, thickness, fontType, charSet,
         edgeSize, Italic, handle
     );
@@ -788,65 +917,13 @@ int InitFontToHandle() {
 }
 
 /* "Default" font functions */
-int DrawString(int x, int y, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor) {
-    return ::DxLib_DrawString(x, y, string, color, edgeColor);
+int ChangeFontA(const char *string, int charSet) {
+    return ::DxLib_ChangeFontA(string, charSet);
 }
-int DrawFormatString(
-    int x, int y, DXCOLOR color,
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_DrawFormatString(x, y, color, formatString, args);
-    va_end(args);
-    return retval;
+int ChangeFontW(const wchar_t *string, int charSet) {
+    return ::DxLib_ChangeFontW(string, charSet);
 }
-int DrawExtendString(int x, int y, double ExRateX, double ExRateY,
-                     const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor) {
-    return ::DxLib_DrawExtendString(x, y, ExRateX, ExRateY, string, color, edgeColor);
-}
-int DrawExtendFormatString(
-    int x, int y, double ExRateX, double ExRateY,
-    DXCOLOR color,
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_DrawExtendFormatString(x, y, ExRateX, ExRateY, color, formatString, args);
-    va_end(args);
-    return retval;
-}
-int GetDrawStringWidth(const DXCHAR *string, int strLen, int VerticalFlag) {
-    return ::DxLib_GetDrawStringWidth(string, strLen, VerticalFlag);
-}
-int GetDrawFormatStringWidth(
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_GetDrawFormatStringWidth(formatString, args);
-    va_end(args);
-    return retval;
-}
-int GetDrawExtendStringWidth(double ExRateX, const DXCHAR *string, int strLen, int VerticalFlag) {
-    return ::DxLib_GetDrawExtendStringWidth(ExRateX, string, strLen, VerticalFlag);
-}
-int GetDrawExtendFormatStringWidth(
-    double ExRateX, const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = ::Dx_Font_GetDrawExtendFormatStringWidth(ExRateX, formatString, args);
-    va_end(args);
-    return retval;
-}
-int ChangeFont(const DXCHAR *string, int charSet) {
-    return ::DxLib_ChangeFont(string, charSet);
-}
+
 int ChangeFontType(int fontType) {
     return ::DxLib_ChangeFontType(fontType);
 }
@@ -862,8 +939,11 @@ int SetFontThickness(int fontThickness) {
 int SetFontSpace(int fontSpace) {
     return ::DxLib_SetFontSpace(fontSpace);
 }
-int SetDefaultFontState(const DXCHAR *fontName, int fontSize, int fontThickness) {
-    return ::DxLib_SetDefaultFontState(fontName, fontSize, fontThickness);
+int SetDefaultFontStateA(const char *fontName, int fontSize, int fontThickness) {
+    return ::DxLib_SetDefaultFontStateA(fontName, fontSize, fontThickness);
+}
+int SetDefaultFontStateW(const wchar_t *fontName, int fontSize, int fontThickness) {
+    return ::DxLib_SetDefaultFontStateW(fontName, fontSize, fontThickness);
 }
 int GetDefaultFontHandle() {
     return ::DxLib_GetDefaultFontHandle();
@@ -901,11 +981,17 @@ int SetUseOldVolumeCalcFlag(int volumeFlag) {
     return ::DxLib_SetUseOldVolumeCalcFlag(volumeFlag);
 }
 
-int LoadSoundMem(const DXCHAR *filename, int bufferNum, int unionHandle) {
-    return ::DxLib_LoadSoundMem(filename, bufferNum, unionHandle);
+int LoadSoundMemA(const char *filename, int bufferNum, int unionHandle) {
+    return ::DxLib_LoadSoundMemA(filename, bufferNum, unionHandle);
 }
-int LoadSoundMem2(const DXCHAR *filename, const DXCHAR *filename2) {
-    return ::DxLib_LoadSoundMem2(filename, filename2);
+int LoadSoundMemW(const wchar_t *filename, int bufferNum, int unionHandle) {
+    return ::DxLib_LoadSoundMemW(filename, bufferNum, unionHandle);
+}
+int LoadSoundMem2A(const char *filename, const char *filename2) {
+    return ::DxLib_LoadSoundMem2A(filename, filename2);
+}
+int LoadSoundMem2W(const wchar_t *filename, const wchar_t *filename2) {
+    return ::DxLib_LoadSoundMem2W(filename, filename2);
 }
 int DeleteSoundMem(int soundID, int LogOutFlag) {
     return ::DxLib_DeleteSoundMem(soundID, LogOutFlag);

--- a/src/DxLib/DxLib_c.c
+++ b/src/DxLib/DxLib_c.c
@@ -362,6 +362,12 @@ int DxLib_GetJoypadNum() {
 int DxLib_GetJoypadInputState(int controllerIndex) {
     return PL_Input_GetJoypadState(controllerIndex);
 }
+int DxLib_GetJoypadAnalogInput(int *x, int *y, int controllerIndex) {
+    return PL_Input_GetJoypadAnalogInput(x, y, controllerIndex);
+}
+int DxLib_GetJoypadAnalogInputRight(int *x, int *y, int controllerIndex) {
+    return PL_Input_GetJoypadAnalogInputRight(x, y, controllerIndex);
+}
 int DxLib_GetJoypadPOVState(int controllerIndex, int povNumber) {
     return PL_Input_GetJoypadPOVState(controllerIndex, povNumber);
 }

--- a/src/DxLib/DxLib_c.c
+++ b/src/DxLib/DxLib_c.c
@@ -3,7 +3,7 @@
   Copyright (C) 2013-2015 Patrick McCarthy <mauve@sandwich.net>
   
   This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
+  mages
   arising from the use of this software.
   
   Permission is granted to anyone to use this software for any purpose,
@@ -27,6 +27,8 @@
 
 #include "PL/PLInternal.h"
 #include "DxInternal.h"
+
+#define DX_STRMAXLEN 4096
 
 /* DxLib_c.c is C bindings to the core internal library. */
 
@@ -234,21 +236,32 @@ int DxLib_EXT_FileRead_SetCharSet(int charset) {
     return PLEXT_FileRead_SetCharSet(charset);
 }
 
-int DxLib_FileRead_open(const DXCHAR *filename, int ASync) {
+int DxLib_FileRead_openA(const char *filename, int ASync) {
     /* FIXME: ASync not supported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_FileRead_open(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
+int DxLib_FileRead_openW(const wchar_t *filename, int ASync) {
+    /* FIXME: ASync not supported */
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_FileRead_open(buf);
+}
 
-int64_t DxLib_FileRead_size(const DXCHAR *filename) {
-    char buf[4096];
+int64_t DxLib_FileRead_sizeA(const char *filename) {
+    char buf[DX_STRMAXLEN];
     return Dx_FileRead_size(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
+}
+int64_t DxLib_FileRead_sizeW(const wchar_t *filename) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_FileRead_size(buf);
 }
 
 int DxLib_FileRead_close(int fileHandle) {
@@ -271,21 +284,23 @@ int DxLib_FileRead_eof(int fileHandle) {
     return Dx_FileRead_eof(fileHandle);
 }
 
-int DxLib_FileRead_gets(DXCHAR *buffer, int bufferSize, int fileHandle) {
+int DxLib_FileRead_getsA(char *buffer, int bufferSize, int fileHandle) {
     return Dx_FileRead_getsA(buffer, bufferSize, fileHandle);
 }
-DXCHAR DxLib_FileRead_getc(int fileHandle) {
+int DxLib_FileRead_getsW(wchar_t *buffer, int bufferSize, int fileHandle) {
+    return Dx_FileRead_getsW(buffer, bufferSize, fileHandle);
+}
+char DxLib_FileRead_getcA(int fileHandle) {
     return Dx_FileRead_getcA(fileHandle);
 }
-int DxLib_FileRead_scanf(int fileHandle, const DXCHAR *format, ...) {
-    va_list args;
-    int retval;
-    
-    va_start(args, format);
-    retval = Dx_FileRead_vscanfA(fileHandle, format, args);
-    va_end(args);
-    
-    return retval;
+wchar_t DxLib_FileRead_getcW(int fileHandle) {
+    return Dx_FileRead_getcW(fileHandle);
+}
+int DxLib_FileRead_vscanfA(int fileHandle, const char *format, va_list args) {
+    return Dx_FileRead_vscanfA(fileHandle, format, args);
+}
+int DxLib_FileRead_vscanfW(int fileHandle, const wchar_t *format, va_list args) {
+    return Dx_FileRead_vscanfW(fileHandle, format, args);
 }
 
 /* ---------------------------------------------------- DxArchive.cpp */
@@ -294,54 +309,87 @@ int DxLib_SetUseDXArchiveFlag(int flag) {
     Dx_File_SetUseDXArchiveFlag(flag);
     return 0;
 }
-int DxLib_SetDXArchiveKeyString(const DXCHAR *keyString) {
-    char buf[4096];
+int DxLib_SetDXArchiveKeyStringA(const char *keyString) {
+    char buf[DX_STRMAXLEN];
     return Dx_File_SetDXArchiveKeyString(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                keyString, g_DxUseCharSet, 4096)
+                keyString, g_DxUseCharSet, DX_STRMAXLEN)
         );
 }
-int DxLib_SetDXArchiveExtension(const DXCHAR *extension) {
-    char buf[4096];
+int DxLib_SetDXArchiveKeyStringW(const wchar_t *keyString) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, keyString, DX_STRMAXLEN);
+    return Dx_File_SetDXArchiveKeyString(buf);
+}
+int DxLib_SetDXArchiveExtensionA(const char *extension) {
+    char buf[DX_STRMAXLEN];
     return Dx_File_SetDXArchiveExtension(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                extension, g_DxUseCharSet, 4096)
+                extension, g_DxUseCharSet, DX_STRMAXLEN)
         );
+}
+int DxLib_SetDXArchiveExtensionW(const wchar_t *extension) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, extension, DX_STRMAXLEN);
+    return Dx_File_SetDXArchiveExtension(buf);
 }
 int DxLib_SetDXArchivePriority(int priority) {
     return Dx_File_SetDXArchivePriority(priority);
 }
-int DxLib_DXArchivePreLoad(const DXCHAR *dxaFilename, int async) {
+int DxLib_DXArchivePreLoadA(const char *dxaFilename, int async) {
     /* FIXME: async is unsupported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_File_DXArchivePreLoad(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                dxaFilename, g_DxUseCharSet, 4096),
+                dxaFilename, g_DxUseCharSet, DX_STRMAXLEN),
         async);
 }
-int DxLib_DXArchiveCheckIdle(const DXCHAR *dxaFilename) {
-    char buf[4096];
+int DxLib_DXArchivePreLoadW(const wchar_t *dxaFilename, int async) {
+    /* FIXME: async is unsupported */
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, dxaFilename, DX_STRMAXLEN);
+    return Dx_File_DXArchivePreLoad(buf, async);
+}
+int DxLib_DXArchiveCheckIdleA(const char *dxaFilename) {
+    char buf[DX_STRMAXLEN];
     return Dx_File_DXArchiveCheckIdle(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                dxaFilename, g_DxUseCharSet, 4096)
+                dxaFilename, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
-int DxLib_DXArchiveRelease(const DXCHAR *dxaFilename) {
-    char buf[4096];
+int DxLib_DXArchiveCheckIdleW(const wchar_t *dxaFilename) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, dxaFilename, DX_STRMAXLEN);
+    return Dx_File_DXArchiveCheckIdle(buf);
+}
+int DxLib_DXArchiveReleaseA(const char *dxaFilename) {
+    char buf[DX_STRMAXLEN];
     return Dx_File_DXArchiveRelease(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                dxaFilename, g_DxUseCharSet, 4096)
+                dxaFilename, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
-int DxLib_DXArchiveCheckFile(const DXCHAR *dxaFilename, const DXCHAR *filename) {
-    char dxabuf[4096];
-    char filebuf[4096];
+int DxLib_DXArchiveReleaseW(const wchar_t *dxaFilename) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, dxaFilename, DX_STRMAXLEN);
+    return Dx_File_DXArchiveRelease(buf);
+}
+int DxLib_DXArchiveCheckFileA(const char *dxaFilename, const char *filename) {
+    char dxabuf[DX_STRMAXLEN];
+    char filebuf[DX_STRMAXLEN];
     return Dx_File_DXArchiveCheckFile(
         PL_Text_ConvertStrncpyIfNecessary(dxabuf, -1,
-                dxaFilename, g_DxUseCharSet, 4096),
+                dxaFilename, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(filebuf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
+}
+int DxLib_DXArchiveCheckFileW(const wchar_t *dxaFilename, const wchar_t *filename) {
+    char dxabuf[DX_STRMAXLEN];
+    char filebuf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(dxabuf, -1, dxaFilename, DX_STRMAXLEN);
+    PL_Text_WideCharToString(filebuf, -1, filename, DX_STRMAXLEN);
+    return Dx_File_DXArchiveCheckFile(dxabuf, filebuf);
 }
 
 /* ---------------------------------------------------- DxInput.cpp */
@@ -425,17 +473,21 @@ int DxLib_SetWindowSizeChangeEnableFlag(int windowResizeFlag, int fitScreen) {
     PL_Window_SetWindowResizeFlag(windowResizeFlag);
     return 0;
 }
-int DxLib_SetWindowText(const DXCHAR *windowName) {
-    char buf[4096];
+int DxLib_SetWindowTextA(const char *windowName) {
+    char buf[DX_STRMAXLEN];
     PL_Window_SetTitle(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                windowName, g_DxUseCharSet, 4096)
+                windowName, g_DxUseCharSet, DX_STRMAXLEN)
     );
     return 0;
 }
-int DxLib_SetMainWindowText(const DXCHAR *windowName) {
-    return DxLib_SetWindowText(windowName);
+int DxLib_SetWindowTextW(const wchar_t *windowName) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, windowName, DX_STRMAXLEN);
+    PL_Window_SetTitle(buf);
+    return 0;
 }
+
 int DxLib_ScreenFlip() {
     if (s_initialized == DXFALSE) {
         return -1;
@@ -467,13 +519,19 @@ int DxLib_GetActiveGraph() {
     return Dx_Draw_GetDrawScreen();
 }
 
-int DxLib_EXT_SetIconImageFile(const DXCHAR *filename) {
-    char buf[4096];
+int DxLib_EXT_SetIconImageFileA(const char *filename) {
+    char buf[DX_STRMAXLEN];
     
     return PL_Window_SetIconFromFile(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
+}
+int DxLib_EXT_SetIconImageFileW(const wchar_t *filename) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    
+    return PL_Window_SetIconFromFile(buf);
 }
 
 int DxLib_SetMouseDispFlag(int flag) {
@@ -501,87 +559,158 @@ int DxLib_GetActiveFlag() {
     return PL_Window_GetActiveFlag();
 }
 
-int DxLib_EXT_MessageBoxError(const DXCHAR *title, const DXCHAR *text) {
-    char titlebuf[4096];
-    char textbuf[4096];
+int DxLib_EXT_MessageBoxErrorA(const char *title, const char *text) {
+    char titlebuf[DX_STRMAXLEN];
+    char textbuf[DX_STRMAXLEN];
     
     return PL_Platform_MessageBoxError(
         PL_Text_ConvertStrncpyIfNecessary(titlebuf, -1,
-                title, g_DxUseCharSet, 4096),
+                title, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(textbuf, -1,
-                text, g_DxUseCharSet, 4096)
+                text, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
-int DxLib_EXT_MessageBoxYesNo(const DXCHAR *title, const DXCHAR *text,
-                              const DXCHAR *button1, const DXCHAR *button2) {
-    char titlebuf[4096];
-    char textbuf[4096];
-    char button1buf[4096];
-    char button2buf[4096];
+int DxLib_EXT_MessageBoxErrorW(const wchar_t *title, const wchar_t *text) {
+    char titlebuf[DX_STRMAXLEN];
+    char textbuf[DX_STRMAXLEN];
+    
+    PL_Text_WideCharToString(titlebuf, -1, title, DX_STRMAXLEN);
+    PL_Text_WideCharToString(textbuf, -1, text, DX_STRMAXLEN);
+    
+    return PL_Platform_MessageBoxError(titlebuf, textbuf);
+}
+int DxLib_EXT_MessageBoxYesNoA(const char *title, const char *text,
+                              const char *button1, const char *button2) {
+    char titlebuf[DX_STRMAXLEN];
+    char textbuf[DX_STRMAXLEN];
+    char button1buf[DX_STRMAXLEN];
+    char button2buf[DX_STRMAXLEN];
     
     return PL_Platform_MessageBoxYesNo(
         PL_Text_ConvertStrncpyIfNecessary(titlebuf, -1,
-                title, g_DxUseCharSet, 4096),
+                title, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(textbuf, -1,
-                text, g_DxUseCharSet, 4096),
+                text, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(button1buf, -1,
-                button1, g_DxUseCharSet, 4096),
+                button1, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(button2buf, -1,
-                button2, g_DxUseCharSet, 4096)
+                button2, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
+int DxLib_EXT_MessageBoxYesNoW(const wchar_t *title, const wchar_t *text,
+                               const wchar_t *button1, const wchar_t *button2) {
+    char titlebuf[DX_STRMAXLEN];
+    char textbuf[DX_STRMAXLEN];
+    char button1buf[DX_STRMAXLEN];
+    char button2buf[DX_STRMAXLEN];
+    
+    PL_Text_WideCharToString(titlebuf, -1, title, DX_STRMAXLEN);
+    PL_Text_WideCharToString(textbuf, -1, text, DX_STRMAXLEN);
+    PL_Text_WideCharToString(button1buf, -1, button1, DX_STRMAXLEN);
+    PL_Text_WideCharToString(button2buf, -1, button2, DX_STRMAXLEN);
+    
+    return PL_Platform_MessageBoxYesNo(
+        titlebuf, textbuf, button1buf, button2buf);
+}
+
 int DxLib_MakeScreen(int width, int height, int hasAlphaChannel) {
     return Dx_Graph_MakeScreen(width, height, hasAlphaChannel);
 }
-int DxLib_LoadGraph(const DXCHAR *filename, int notUse3DFlag) {
+
+int DxLib_LoadGraphA(const char *filename, int notUse3DFlag) {
     /* FIXME: notUse3DFlag is unsupported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_Graph_Load(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         DXFALSE);
-    
 }
-int DxLib_LoadReverseGraph(const DXCHAR *filename, int notUse3DFlag) {
+int DxLib_LoadGraphW(const wchar_t *filename, int notUse3DFlag) {
     /* FIXME: notUse3DFlag is unsupported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_Graph_Load(buf, DXFALSE);
+}
+
+int DxLib_LoadReverseGraphA(const char *filename, int notUse3DFlag) {
+    /* FIXME: notUse3DFlag is unsupported */
+    char buf[DX_STRMAXLEN];
     return Dx_Graph_Load(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         DXTRUE);
 }
-int DxLib_LoadDivGraph(const DXCHAR *filename, int graphCount,
-                       int xCount, int yCount, int xSize, int ySize,
-                       int *handleBuf, int notUse3DFlag) {
+int DxLib_LoadReverseGraphW(const wchar_t *filename, int notUse3DFlag) {
     /* FIXME: notUse3DFlag is unsupported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_Graph_Load(buf, DXTRUE);
+}
+
+int DxLib_LoadDivGraphA(const char *filename, int graphCount,
+                        int xCount, int yCount, int xSize, int ySize,
+                        int *handleBuf, int notUse3DFlag) {
+    /* FIXME: notUse3DFlag is unsupported */
+    char buf[DX_STRMAXLEN];
     return Dx_Graph_LoadDiv(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         graphCount, xCount, yCount, xSize, ySize,
         handleBuf, DXFALSE, DXFALSE);
 }
-int DxLib_LoadDivBmpGraph(const DXCHAR *filename, int graphCount,
+int DxLib_LoadDivGraphW(const wchar_t *filename, int graphCount,
+                        int xCount, int yCount, int xSize, int ySize,
+                        int *handleBuf, int notUse3DFlag) {
+    /* FIXME: notUse3DFlag is unsupported */
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_Graph_LoadDiv(
+        buf, graphCount, xCount, yCount, xSize, ySize,
+        handleBuf, DXFALSE, DXFALSE);
+}
+
+int DxLib_LoadDivBmpGraphA(const char *filename, int graphCount,
                           int xCount, int yCount, int xSize, int ySize,
                           int *handleBuf, int textureFlag, int flipFlag) {
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_Graph_LoadDiv(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         graphCount, xCount, yCount, xSize, ySize,
         handleBuf, textureFlag, flipFlag);
 }
-int DxLib_LoadReverseDivGraph(const DXCHAR *filename, int graphCount,
-                              int xCount, int yCount, int xSize, int ySize,
-                              int *handleBuf, int notUse3DFlag) {
+int DxLib_LoadDivBmpGraphW(const wchar_t *filename, int graphCount,
+                           int xCount, int yCount, int xSize, int ySize,
+                           int *handleBuf, int textureFlag, int flipFlag) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_Graph_LoadDiv(
+        buf, graphCount, xCount, yCount, xSize, ySize,
+        handleBuf, textureFlag, flipFlag);
+}
+
+int DxLib_LoadReverseDivGraphA(const char *filename, int graphCount,
+                               int xCount, int yCount, int xSize, int ySize,
+                               int *handleBuf, int notUse3DFlag) {
     /* FIXME: notUse3DFlag is unsupported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_Graph_LoadDiv(
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         graphCount, xCount, yCount, xSize, ySize,
         handleBuf, DXFALSE, DXTRUE);
 }
+int DxLib_LoadReverseDivGraphW(const wchar_t *filename, int graphCount,
+                               int xCount, int yCount, int xSize, int ySize,
+                               int *handleBuf, int notUse3DFlag) {
+    /* FIXME: notUse3DFlag is unsupported */
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return Dx_Graph_LoadDiv(
+        buf, graphCount, xCount, yCount, xSize, ySize,
+        handleBuf, DXFALSE, DXTRUE);
+}
+
 int DxLib_DeleteGraph(int graphID, int LogOutFlag) {
     /* FIXME: LogOutFlag is unsupported */
     return Dx_Graph_Delete(graphID);
@@ -877,52 +1006,96 @@ int DxLib_ClsDrawScreen() {
     return Dx_Draw_ClearDrawScreen(NULL);
 }
 
-int DxLib_SaveDrawScreen(int x1, int y1, int x2, int y2,
-                         const DXCHAR *filename, int saveType,
-                         int jpegQuality, int jpegSample2x1,
-                         int pngCompressionLevel) {
+int DxLib_SaveDrawScreenA(int x1, int y1, int x2, int y2,
+                          const char *filename, int saveType,
+                          int jpegQuality, int jpegSample2x1,
+                          int pngCompressionLevel) {
     switch(saveType) {
         case DX_IMAGESAVETYPE_BMP:
-            return DxLib_SaveDrawScreenToBMP(x1, y1, x2, y2, filename);
+            return DxLib_SaveDrawScreenToBMPA(x1, y1, x2, y2, filename);
         case DX_IMAGESAVETYPE_JPEG:
-            return DxLib_SaveDrawScreenToJPEG(x1, y1, x2, y2, filename,
-                                              jpegQuality, jpegSample2x1);
+            return DxLib_SaveDrawScreenToJPEGA(x1, y1, x2, y2, filename,
+                                               jpegQuality, jpegSample2x1);
         case DX_IMAGESAVETYPE_PNG:
-            return DxLib_SaveDrawScreenToPNG(x1, y1, x2, y2, filename,
-                                             pngCompressionLevel);
+            return DxLib_SaveDrawScreenToPNGA(x1, y1, x2, y2, filename,
+                                              pngCompressionLevel);
+        default:
+            return -1;
+    }
+}
+int DxLib_SaveDrawScreenW(int x1, int y1, int x2, int y2,
+                          const wchar_t *filename, int saveType,
+                          int jpegQuality, int jpegSample2x1,
+                          int pngCompressionLevel) {
+    switch(saveType) {
+        case DX_IMAGESAVETYPE_BMP:
+            return DxLib_SaveDrawScreenToBMPW(x1, y1, x2, y2, filename);
+        case DX_IMAGESAVETYPE_JPEG:
+            return DxLib_SaveDrawScreenToJPEGW(x1, y1, x2, y2, filename,
+                                               jpegQuality, jpegSample2x1);
+        case DX_IMAGESAVETYPE_PNG:
+            return DxLib_SaveDrawScreenToPNGW(x1, y1, x2, y2, filename,
+                                              pngCompressionLevel);
         default:
             return -1;
     }
 }
 
-int DxLib_SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                              const DXCHAR *filename) {
-    char buf[4096];
+int DxLib_SaveDrawScreenToBMPA(int x1, int y1, int x2, int y2,
+                               const char *filename) {
+    char buf[DX_STRMAXLEN];
     return PL_SaveDrawScreenToBMP(x1, y1, x2, y2,
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
-int DxLib_SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                               const DXCHAR *filename,
-                               int quality, int sample2x1) {
-    char buf[4096];
+int DxLib_SaveDrawScreenToBMPW(int x1, int y1, int x2, int y2,
+                               const wchar_t *filename) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return PL_SaveDrawScreenToBMP(x1, y1, x2, y2, buf);
+}
+
+int DxLib_SaveDrawScreenToJPEGA(int x1, int y1, int x2, int y2,
+                                const char *filename,
+                                int quality, int sample2x1) {
+    char buf[DX_STRMAXLEN];
     return PL_SaveDrawScreenToJPEG(
         x1, y1, x2, y2,
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         quality, sample2x1);
 
 }
-int DxLib_SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                              const DXCHAR *filename,
-                              int compressionLevel) {
-    char buf[4096];
+int DxLib_SaveDrawScreenToJPEGW(int x1, int y1, int x2, int y2,
+                                const wchar_t *filename,
+                                int quality, int sample2x1) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return PL_SaveDrawScreenToJPEG(
+        x1, y1, x2, y2, buf,
+        quality, sample2x1);
+
+}
+
+int DxLib_SaveDrawScreenToPNGA(int x1, int y1, int x2, int y2,
+                               const char *filename,
+                               int compressionLevel) {
+    char buf[DX_STRMAXLEN];
     return PL_SaveDrawScreenToPNG(
         x1, y1, x2, y2,
         PL_Text_ConvertStrncpyIfNecessary(buf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         compressionLevel);
+}
+int DxLib_SaveDrawScreenToPNGW(int x1, int y1, int x2, int y2,
+                               const wchar_t *filename,
+                               int compressionLevel) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, filename, DX_STRMAXLEN);
+    return PL_SaveDrawScreenToPNG(
+        x1, y1, x2, y2,
+        buf, compressionLevel);
 }
 
 DXCOLOR DxLib_GetColor(int red, int green, int blue) {
@@ -932,121 +1105,191 @@ DXCOLOR DxLib_GetColor(int red, int green, int blue) {
 /* ---------------------------------------------------- DxFont.cpp */
 #ifndef DX_NON_FONT
 
-int DxLib_EXT_MapFontFileToName(const DXCHAR *filename,
-                                const DXCHAR *fontname,
-                                int thickness,
-                                int boldFlag,
-                                double exRateX,
-                                double exRateY
-                               ) {
-    char filebuf[4096];
-    char fontbuf[4096];
+int DxLib_EXT_MapFontFileToNameA(
+        const char *filename, const char *fontname,
+        int thickness, int boldFlag,
+        double exRateX, double exRateY
+) {
+    char filebuf[DX_STRMAXLEN];
+    char fontbuf[DX_STRMAXLEN];
     return PLEXT_Font_MapFontFileToName(
         PL_Text_ConvertStrncpyIfNecessary(
-            filebuf, -1, filename, g_DxUseCharSet, 4096),
+            filebuf, -1, filename, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(
-            fontbuf, -1, fontname, g_DxUseCharSet, 4096),
+            fontbuf, -1, fontname, g_DxUseCharSet, DX_STRMAXLEN),
         thickness, boldFlag, exRateX, exRateY);
 }
+int DxLib_EXT_MapFontFileToNameW(
+        const wchar_t *filename, const wchar_t *fontname,
+        int thickness, int boldFlag,
+        double exRateX, double exRateY
+) {
+    char filebuf[DX_STRMAXLEN];
+    char fontbuf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(filebuf, -1, filename, DX_STRMAXLEN);
+    PL_Text_WideCharToString(fontbuf, -1, fontname, DX_STRMAXLEN);
+    return PLEXT_Font_MapFontFileToName(
+        filebuf, fontbuf,
+        thickness, boldFlag, exRateX, exRateY);
+}
+
 int DxLib_EXT_InitFontMappings() {
     return PLEXT_Font_InitFontMappings();
 }
 
 /* Handle font functions */
-int DxLib_DrawStringToHandle(int x, int y, const DXCHAR *text,
+int DxLib_DrawStringToHandleA(int x, int y, const char *text,
+                              DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                              int VerticalFlag) {
+    return Dx_Font_DrawStringA(x, y, 1, 1, text, color,
+                               fontHandle, edgeColor, VerticalFlag);
+}
+int DxLib_DrawStringToHandleW(int x, int y, const wchar_t *text,
                              DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
                              int VerticalFlag) {
-    /* FIXME: VerticalFlag unsupported */
-    return Dx_Font_DrawStringToHandle(x, y, text, color, fontHandle, edgeColor);
+    return Dx_Font_DrawStringW(x, y, 1, 1, text, color,
+                               fontHandle, edgeColor, VerticalFlag);
 }
-int DxLib_DrawFormatStringToHandle(
+int DxLib_DrawFormatVStringToHandleA(
     int x, int y, DXCOLOR color, int fontHandle,
-    const DXCHAR *formatString, ...
+    const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_DrawFormatStringToHandle(x, y, color, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return Dx_Font_DrawVStringFA(x, y, 1, 1, color, fontHandle, 0, DXFALSE, formatString, args);
 }
-int DxLib_DrawExtendStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                                   const DXCHAR *text,
-                                   DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
-                                   int VerticalFlag) {
-    /* FIXME: VerticalFlag unsupported */
-    return Dx_Font_DrawExtendStringToHandle(x, y, ExRateX, ExRateY, text, color, fontHandle, edgeColor);
-}
-int DxLib_DrawExtendFormatStringToHandle(
-    int x, int y, double ExRateX, double ExRateY, DXCOLOR color, int fontHandle,
-    const DXCHAR *formatString, ...
+int DxLib_DrawFormatVStringToHandleW(
+    int x, int y, DXCOLOR color, int fontHandle,
+    const wchar_t *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_DrawExtendFormatStringToHandle(x, y, ExRateX, ExRateY, color, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return Dx_Font_DrawVStringFW(x, y, 1, 1, color, fontHandle, 0, DXFALSE, formatString, args);
+}
+int DxLib_DrawExtendStringToHandleA(int x, int y, double ExRateX, double ExRateY,
+                                    const char *text,
+                                    DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                                    int VerticalFlag) {
+    return Dx_Font_DrawStringA(x, y, ExRateX, ExRateY,
+                               text, color, fontHandle, 0, VerticalFlag);
+}
+int DxLib_DrawExtendStringToHandleW(int x, int y, double ExRateX, double ExRateY,
+                                    const wchar_t *text,
+                                    DXCOLOR color, int fontHandle, DXCOLOR edgeColor,
+                                    int VerticalFlag) {
+    return Dx_Font_DrawStringW(x, y, ExRateX, ExRateY,
+                               text, color, fontHandle, 0, VerticalFlag);
 }
 
-int DxLib_GetDrawStringWidthToHandle(const DXCHAR *string, int strLen, int fontHandle,
-                                     int VerticalFlag) {
-    /* FIXME: VerticalFlag unsupported */
-    return Dx_Font_GetDrawStringWidthToHandle(string, strLen, fontHandle);
-}
-int DxLib_GetDrawFormatStringWidthToHandle(
-    int fontHandle, const DXCHAR *formatString, ...
+int DxLib_DrawExtendFormatVStringToHandleA(
+    int x, int y, double ExRateX, double ExRateY, DXCOLOR color, int fontHandle,
+    const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_GetDrawFormatStringWidthToHandle(fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return Dx_Font_DrawVStringFA(
+        x, y, ExRateX, ExRateY, color, fontHandle, 0, DXFALSE,
+        formatString, args);
 }
-int DxLib_GetDrawExtendStringWidthToHandle(double ExRateX, const DXCHAR *string, int strLen,
+int DxLib_DrawExtendFormatVStringToHandleW(
+    int x, int y, double ExRateX, double ExRateY, DXCOLOR color, int fontHandle,
+    const wchar_t *formatString, va_list args
+) {
+    wchar_t buf[4096];
+    PL_Text_Wvsnprintf(buf, 4096, g_DxUseCharSet, formatString, args);
+    return Dx_Font_DrawVStringFW(
+        x, y, ExRateX, ExRateY, color, fontHandle, 0, DXFALSE,
+        formatString, args);
+}
+
+int DxLib_GetDrawStringWidthToHandleA(const char *string, int strLen, int fontHandle,
+                                      int VerticalFlag) {
+    return Dx_Font_GetStringWidthA(string, strLen, fontHandle);
+}
+int DxLib_GetDrawStringWidthToHandleW(const wchar_t *string, int strLen, int fontHandle,
+                                      int VerticalFlag) {
+    return Dx_Font_GetStringWidthW(string, strLen, fontHandle);
+}
+
+int DxLib_GetDrawFormatVStringWidthToHandleA(
+    int fontHandle, const char *formatString, va_list args
+) {
+    return Dx_Font_GetVStringWidthFA(fontHandle, -1, formatString, args);
+}
+int DxLib_GetDrawFormatVStringWidthToHandleW(
+    int fontHandle, const wchar_t *formatString, va_list args
+) {
+    return Dx_Font_GetVStringWidthFW(fontHandle, -1, formatString, args);
+}
+int DxLib_GetDrawExtendStringWidthToHandleA(double ExRateX, const char *string, int strLen,
                                            int fontHandle, int VerticalFlag) {
     /* FIXME: VerticalFlag unsupported */
-    return Dx_Font_GetDrawExtendStringWidthToHandle(ExRateX, string, strLen, fontHandle);
+    return (int)SDL_ceil(Dx_Font_GetStringWidthA(string, strLen, fontHandle) * ExRateX);
 }
-int DxLib_GetDrawExtendFormatStringWidthToHandle(
-    double ExRateX, int fontHandle, const DXCHAR *formatString, ...
+int DxLib_GetDrawExtendStringWidthToHandleW(double ExRateX, const wchar_t *string, int strLen,
+                                            int fontHandle, int VerticalFlag) {
+    /* FIXME: VerticalFlag unsupported */
+    return (int)SDL_ceil(Dx_Font_GetStringWidthW(string, strLen, fontHandle) * ExRateX);
+}
+int DxLib_GetDrawExtendFormatVStringWidthToHandleA(
+    double ExRateX, int fontHandle, const char *formatString, va_list args
 ) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_GetDrawExtendFormatStringWidthToHandle(ExRateX, fontHandle, formatString, args);
-    va_end(args);
-    return retval;
+    return (int)SDL_ceil(Dx_Font_GetVStringWidthFA(fontHandle, -1, formatString, args) * ExRateX);
 }
-
+int DxLib_GetDrawExtendFormatVStringWidthToHandleW(
+    double ExRateX, int fontHandle, const wchar_t *formatString, va_list args
+) {
+    return (int)SDL_ceil(Dx_Font_GetVStringWidthFW(fontHandle, -1, formatString, args) * ExRateX);
+}
 
 int DxLib_GetFontSizeToHandle(int fontHandle) {
     return Dx_Font_GetFontSizeToHandle(fontHandle);
 }
-int DxLib_GetFontCharInfo(int fontHandle, const DXCHAR *string,
-                          int *xPos, int *yPos, int *advanceX,
-                          int *width, int *height) {
-    return Dx_Font_GetFontCharInfo(fontHandle, string, xPos, yPos, advanceX, width, height);
+
+int DxLib_GetFontCharInfoA(int fontHandle, const char *string,
+                           int *xPos, int *yPos, int *advanceX,
+                           int *width, int *height) {
+    char buf[DX_STRMAXLEN];
+    return Dx_Font_GetFontCharInfo(
+        fontHandle,
+        PL_Text_ConvertStrncpyIfNecessary(
+            buf, -1,
+            string, g_DxUseCharSet,
+            DX_STRMAXLEN),
+        xPos, yPos, advanceX, width, height);
 }
+int DxLib_GetFontCharInfoW(int fontHandle, const wchar_t *string,
+                           int *xPos, int *yPos, int *advanceX,
+                           int *width, int *height) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, string, DX_STRMAXLEN);
+    return Dx_Font_GetFontCharInfo(fontHandle, buf, xPos, yPos, advanceX, width, height);
+}
+
 int DxLib_SetFontSpaceToHandle(int fontSpacing, int fontHandle) {
     return Dx_Font_SetFontSpaceToHandle(fontSpacing, fontHandle);
 }
 
-int DxLib_CreateFontToHandle(const DXCHAR *fontname,
-                       int size, int thickness, int fontType, int charSet,
-                       int edgeSize, int Italic, int handle) {
+int DxLib_CreateFontToHandleA(const char *fontname,
+                              int size, int thickness, int fontType, int charSet,
+                              int edgeSize, int Italic, int handle) {
     /* FIXME: handle not supported */
-    char buf[4096];
+    char buf[DX_STRMAXLEN];
     return Dx_Font_CreateFontToHandle(
         PL_Text_ConvertStrncpyIfNecessary(
             buf, -1,
             fontname, g_DxUseCharSet,
-            4096),
+            DX_STRMAXLEN),
         size, thickness, fontType, charSet,
         edgeSize, Italic
     );
 }
+int DxLib_CreateFontToHandleW(const wchar_t *fontname,
+                              int size, int thickness, int fontType, int charSet,
+                              int edgeSize, int Italic, int handle) {
+    /* FIXME: handle not supported */
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, fontname, DX_STRMAXLEN);
+    return Dx_Font_CreateFontToHandle(
+        buf, size, thickness, fontType, charSet,
+        edgeSize, Italic
+    );
+}
+
 int DxLib_DeleteFontToHandle(int fontHandle) {
     return Dx_Font_DeleteFontToHandle(fontHandle);
 }
@@ -1062,70 +1305,19 @@ int DxLib_InitFontToHandle() {
 }
 
 /* "Default" font functions */
-int DxLib_DrawString(int x, int y, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor) {
-    return Dx_Font_DrawString(x, y, string, color, edgeColor);
+int DxLib_ChangeFontA(const char *string, int charSet) {
+    char buf[DX_STRMAXLEN];
+    return Dx_Font_ChangeFont(
+        PL_Text_ConvertStrncpyIfNecessary(
+            buf, -1, string, g_DxUseCharSet, DX_STRMAXLEN),
+        charSet);
 }
-int DxLib_DrawFormatString(
-    int x, int y, DXCOLOR color,
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_DrawFormatString(x, y, color, formatString, args);
-    va_end(args);
-    return retval;
-}
-int DxLib_DrawExtendString(int x, int y, double ExRateX, double ExRateY,
-                           const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor) {
-    return Dx_Font_DrawExtendString(x, y, ExRateX, ExRateY, string, color, edgeColor);
-}
-int DxLib_DrawExtendFormatString(
-    int x, int y, double ExRateX, double ExRateY,
-    DXCOLOR color,
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_DrawExtendFormatString(x, y, ExRateX, ExRateY, color, formatString, args);
-    va_end(args);
-    return retval;
+int DxLib_ChangeFontW(const wchar_t *string, int charSet) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, string, DX_STRMAXLEN);
+    return Dx_Font_ChangeFont(buf, charSet);
 }
 
-int DxLib_GetDrawStringWidth(const DXCHAR *string, int strLen, int VerticalFlag) {
-    /* FIXME: handle not supported */
-    return Dx_Font_GetDrawStringWidth(string, strLen);
-}
-int DxLib_GetDrawFormatStringWidth(
-    const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_GetDrawFormatStringWidth(formatString, args);
-    va_end(args);
-    return retval;
-}
-int DxLib_GetDrawExtendStringWidth(double ExRateX, const DXCHAR *string, int strLen,
-                                   int VerticalFlag) {
-    /* FIXME: handle not supported */
-    return Dx_Font_GetDrawExtendStringWidth(ExRateX, string, strLen);
-}
-int DxLib_GetDrawExtendFormatStringWidth(
-    double ExRateX, const DXCHAR *formatString, ...
-) {
-    va_list args;
-    int retval;
-    va_start(args, formatString);
-    retval = Dx_Font_GetDrawExtendFormatStringWidth(ExRateX, formatString, args);
-    va_end(args);
-    return retval;
-}
-
-int DxLib_ChangeFont(const DXCHAR *string, int charSet) {
-    return Dx_Font_ChangeFont(string, charSet);
-}
 int DxLib_ChangeFontType(int fontType) {
     return Dx_Font_ChangeFontType(fontType);
 }
@@ -1141,9 +1333,20 @@ int DxLib_SetFontThickness(int fontThickness) {
 int DxLib_SetFontSpace(int fontSpace) {
     return Dx_Font_SetFontSpace(fontSpace);
 }
-int DxLib_SetDefaultFontState(const DXCHAR *fontName, int fontSize, int fontThickness) {
-    return Dx_Font_SetDefaultFontState(fontName, fontSize, fontThickness);
+
+int DxLib_SetDefaultFontStateA(const char *fontName, int fontSize, int fontThickness) {
+    char buf[DX_STRMAXLEN];
+    return Dx_Font_SetDefaultFontState(
+        PL_Text_ConvertStrncpyIfNecessary(
+            buf, -1, fontName, g_DxUseCharSet, DX_STRMAXLEN),
+        fontSize, fontThickness);
 }
+int DxLib_SetDefaultFontStateW(const wchar_t *fontName, int fontSize, int fontThickness) {
+    char buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(buf, -1, fontName, DX_STRMAXLEN);
+    return Dx_Font_SetDefaultFontState(buf, fontSize, fontThickness);
+}
+
 int DxLib_GetDefaultFontHandle() {
     return Dx_Font_GetDefaultFontHandle();
 }
@@ -1180,24 +1383,39 @@ int DxLib_SetUseOldVolumeCalcFlag(int volumeFlag) {
     return PL_SetUseOldVolumeCalcFlag(volumeFlag);
 }
 
-int DxLib_LoadSoundMem(const DXCHAR *filename, int bufferNum, int unionHandle) {
+int DxLib_LoadSoundMemA(const char *filename, int bufferNum, int unionHandle) {
     /* FIXME: bufferNum and unionHandle are unsupported */
-    char filebuf[4096];
+    char filebuf[DX_STRMAXLEN];
     return PL_LoadSoundMem(
         PL_Text_ConvertStrncpyIfNecessary(filebuf, -1,
-                filename, g_DxUseCharSet, 4096)
+                filename, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
-int DxLib_LoadSoundMem2(const DXCHAR *filename, const DXCHAR *filename2) {
-    char filebuf[4096];
-    char file2buf[4096];
+int DxLib_LoadSoundMemW(const wchar_t *filename, int bufferNum, int unionHandle) {
+    /* FIXME: bufferNum and unionHandle are unsupported */
+    char filebuf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(filebuf, -1, filename, DX_STRMAXLEN);
+    return PL_LoadSoundMem(filebuf);
+}
+
+int DxLib_LoadSoundMem2A(const char *filename, const char *filename2) {
+    char filebuf[DX_STRMAXLEN];
+    char file2buf[DX_STRMAXLEN];
     return PL_LoadSoundMem2(
         PL_Text_ConvertStrncpyIfNecessary(filebuf, -1,
-                filename, g_DxUseCharSet, 4096),
+                filename, g_DxUseCharSet, DX_STRMAXLEN),
         PL_Text_ConvertStrncpyIfNecessary(file2buf, -1,
-                filename2, g_DxUseCharSet, 4096)
+                filename2, g_DxUseCharSet, DX_STRMAXLEN)
     );
 }
+int DxLib_LoadSoundMem2W(const wchar_t *filename, const wchar_t *filename2) {
+    char filebuf[DX_STRMAXLEN];
+    char file2buf[DX_STRMAXLEN];
+    PL_Text_WideCharToString(filebuf, -1, filename, DX_STRMAXLEN);
+    PL_Text_WideCharToString(file2buf, -1, filename2, DX_STRMAXLEN);
+    return PL_LoadSoundMem2(filebuf, file2buf);
+}
+
 int DxLib_DeleteSoundMem(int soundID, int LogOutFlag) {
     /* FIXME: LogOutFlag is unsupported */
     return PL_DeleteSoundMem(soundID);

--- a/src/Luna/Luna.cpp
+++ b/src/Luna/Luna.cpp
@@ -414,7 +414,7 @@ void Luna::EXTSetOnlyWindowSize(int width, int height, bool isFullscreen, bool i
     s_lunaFullscreenDesktopFlag = newDesktopFlag;
 }
 
-void Luna::EXTSetWindowIconFromFile(const DXCHAR *filename) {
+void Luna::EXTSetWindowIconFromFile(const char *filename) {
     char buf[2048];
     PL_Window_SetIconFromFile(
         PL_Text_ConvertStrncpyIfNecessary(

--- a/src/Luna/LunaFontSprite.cpp
+++ b/src/Luna/LunaFontSprite.cpp
@@ -86,8 +86,8 @@ typedef struct _LunaFontSprData {
 
 static const char lfd_id[4] = { 'L', 'F', 'D', 0x00 };
 
-LFONTSPRITE LunaFontSprite::CreateFromFile(const DXCHAR *pFileName,
-                                 const DXCHAR *pExt, Bool IsAlpha, Uint32 Num,
+LFONTSPRITE LunaFontSprite::CreateFromFile(const char *pFileName,
+                                 const char *pExt, Bool IsAlpha, Uint32 Num,
                                  Bool IsSortZ,
                                  eSurfaceFormat Format) {
     char filebuf[4096];
@@ -241,7 +241,7 @@ static unsigned int s_CharToIndex(LunaFontSprData *fontspr, unsigned int ch) {
     return fontspr->lfdIndex[lookup];
 }
 
-void LunaFontSprite::DrawString(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+void LunaFontSprite::DrawString(LFONTSPRITE lFontSpr, const char *pStr,
                           Sint32 Px, Sint32 Py, Float Pz, D3DCOLOR Color) {
     LunaFontSprData *fontspr = (LunaFontSprData *)PL_Handle_GetData((int)lFontSpr, DXHANDLE_LUNAFONTSPRITE);
     if (fontspr != NULL) {
@@ -295,7 +295,7 @@ void LunaFontSprite::DrawString(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
     }
 }
 
-void LunaFontSprite::DrawStringP(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+void LunaFontSprite::DrawStringP(LFONTSPRITE lFontSpr, const char *pStr,
                           Sint32 Px, Sint32 Py, Float Pz, D3DCOLOR Color) {
     LunaFontSprData *fontspr = (LunaFontSprData *)PL_Handle_GetData((int)lFontSpr, DXHANDLE_LUNAFONTSPRITE);
     if (fontspr != NULL) {
@@ -377,7 +377,7 @@ void LunaFontSprite::Rendering(LFONTSPRITE lFontSpr) {
     }
 }
 
-Bool LunaFontSprite::GetWidth(LFONTSPRITE lFontSpr, const DXCHAR *pStr,
+Bool LunaFontSprite::GetWidth(LFONTSPRITE lFontSpr, const char *pStr,
                          Sint32 *pLeft, Sint32 *pCenter, Sint32 *pRight) {
     LunaFontSprData *fontspr = (LunaFontSprData *)PL_Handle_GetData((int)lFontSpr, DXHANDLE_LUNAFONTSPRITE);
     if (fontspr != NULL) {

--- a/src/Luna/LunaFontSprite.cpp
+++ b/src/Luna/LunaFontSprite.cpp
@@ -152,11 +152,11 @@ LFONTSPRITE LunaFontSprite::CreateFromFile(const char *pFileName,
             memcpy(buf, lfdData + sizeof(LFDHeader) + (sizeof(Uint16) * CODE_TABLE_SIZE) + (32 * i), 32);
             buf[32] = '\0';
             if (pExt != NULL) {
-                char newBuf[256];
-                PL_Text_ConvertStrncpyIfNecessary(
-                    newBuf, -1, buf, g_lunaUseCharSet, 256);
+                char newBuf[2048];
+                PL_Text_ConvertStrncpy(
+                    newBuf, -1, buf, g_lunaUseCharSet, 2048);
                 PL_Text_ConvertStrncat(
-                    newBuf, -1, pExt, g_lunaUseCharSet, 256);
+                    newBuf, -1, pExt, g_lunaUseCharSet, 2048);
                 
                 int surface = PL_Surface_Load(newBuf);
                 fontspr->sheetGraphs[i] = PL_Surface_ToTexture(surface);

--- a/src/Luna/LunaInternal.h
+++ b/src/Luna/LunaInternal.h
@@ -207,6 +207,7 @@ extern int g_lunaFilterMode;
 extern int g_luna3DCamera;
 extern float g_lunaVirtualXmult;
 extern float g_lunaVirtualYmult;
+extern int g_lunaUseCharSet;
 
 extern int g_lunaAlphaTestPreset;
 extern float g_lunaAlphaTestValue;

--- a/src/Luna/LunaSound.cpp
+++ b/src/Luna/LunaSound.cpp
@@ -31,8 +31,11 @@ LSOUND LunaSound::CreateFromFile(const DXCHAR *filename, bool IsNoStop,
                                  bool IsAyame, bool IsHardware, Uint32 Layer) {
     /* We don't care about IsAyame or IsHardware. Or even Layer.
      * We do care about IsNoStop. */
-    
-    return PL_LoadSoundMem(filename);
+    char buf[2048];
+    return PL_LoadSoundMem(
+        PL_Text_ConvertStrncpyIfNecessary(
+            buf, -1, filename, g_lunaUseCharSet, 2048)
+    );
 }
 Bool LunaSound::IsPlay(LSOUND lSnd, Uint32 Layer) {
     if (PL_CheckSoundMem((int)lSnd) == DXTRUE) {

--- a/src/Luna/LunaSound.cpp
+++ b/src/Luna/LunaSound.cpp
@@ -27,7 +27,7 @@
 
 #ifndef DX_NON_SOUND
 
-LSOUND LunaSound::CreateFromFile(const DXCHAR *filename, bool IsNoStop,
+LSOUND LunaSound::CreateFromFile(const char *filename, bool IsNoStop,
                                  bool IsAyame, bool IsHardware, Uint32 Layer) {
     /* We don't care about IsAyame or IsHardware. Or even Layer.
      * We do care about IsNoStop. */
@@ -69,7 +69,7 @@ void LunaSound::SetPan(LSOUND lSnd, Float fParam, Uint32 Layer) {
 void LunaSound::SetMax(Uint32 Max) {
     /* Sets maximum number of sounds. Doesn't matter for PL. */
 }
-void LunaSound::SetAyamePath(const DXCHAR *pPath) {
+void LunaSound::SetAyamePath(const char *pPath) {
     /* Stub. Does nothing. */
 }
 void LunaSound::EXTSetLoopSamples(LSOUND lSnd, Uint64 loopTarget, Uint64 loopPoint) {
@@ -82,7 +82,7 @@ void LunaSound::EXTSetLoopTimes(LSOUND lSnd, double loopTarget, double loopTime)
 #else
 /* DX_NON_SOUND */
 
-LSOUND LunaSound::CreateFromFile(const DXCHAR *filename, bool IsNoStop,
+LSOUND LunaSound::CreateFromFile(const char *filename, bool IsNoStop,
                                  bool IsAyame, bool IsHardware, Uint32 Layer) {
     return -1;
 }
@@ -105,7 +105,7 @@ void LunaSound::SetPan(LSOUND lSnd, Float fParam, Uint32 Layer) {
 }
 void LunaSound::SetMax(Uint32 Max) {
 }
-void LunaSound::SetAyamePath(const DXCHAR *pPath) {
+void LunaSound::SetAyamePath(const char *pPath) {
 }
 void LunaSound::EXTSetLoopSamples(LSOUND lSnd, Uint64 loopTarget, Uint64 loopPoint) {
 }

--- a/src/Luna/LunaTexture.cpp
+++ b/src/Luna/LunaTexture.cpp
@@ -28,7 +28,7 @@
 #include "PL/PLInternal.h"
 #include "LunaInternal.h"
 
-LTEXTURE LunaTexture::CreateFromFile(const DXCHAR *pFileName,
+LTEXTURE LunaTexture::CreateFromFile(const char *pFileName,
                                      eSurfaceFormat format,
                                      D3DCOLOR keyColor) {
     char buf[2048];
@@ -54,8 +54,8 @@ LTEXTURE LunaTexture::CreateFromFile(const DXCHAR *pFileName,
     return handle;
 }
 
-LTEXTURE LunaTexture::CreateFromLAG(const DXCHAR *pFileName,
-                                    const DXCHAR *pDataName,
+LTEXTURE LunaTexture::CreateFromLAG(const char *pFileName,
+                                    const char *pDataName,
                                     eSurfaceFormat format) {
     /* Not supported yet. */
     return INVALID_TEXTURE;

--- a/src/Luna/LunaTexture.cpp
+++ b/src/Luna/LunaTexture.cpp
@@ -31,7 +31,11 @@
 LTEXTURE LunaTexture::CreateFromFile(const DXCHAR *pFileName,
                                      eSurfaceFormat format,
                                      D3DCOLOR keyColor) {
-    int surfaceID = PL_Surface_Load(pFileName);
+    char buf[2048];
+    int surfaceID = PL_Surface_Load(
+        PL_Text_ConvertStrncpyIfNecessary(
+            buf, -1, pFileName, g_lunaUseCharSet, 2048)
+    );
     int handle;
     
     if (surfaceID < 0) {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ libDxPortLib_la_SOURCES =	\
 	PL/SDL2/PLSDL2Window.c \
 	PL/SDL2/PLSDL2Memory.c \
 	PL/SDL2/PLSDL2SaveScreen.c \
+	PL/SDL2/PLSDL2System.c \
 	PL/PLSurface.c \
 	PL/PLText.c \
 	PL/PLText_CP932.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,6 +53,8 @@ libDxPortLib_la_SOURCES =	\
 	PL/SDL2/PLSDL2System.c \
 	PL/PLSurface.c \
 	PL/PLText.c \
+	PL/PLTextSnprintf.c \
+	PL/PLTextSscanf.c \
 	PL/PLText_CP932.c
 
 libDxPortLib_la_LDFLAGS = -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)

--- a/src/PL/PLAudio.c
+++ b/src/PL/PLAudio.c
@@ -676,7 +676,7 @@ static void s_AudioClose() {
 
 /* ------------------------------------------------------ DXLIB INTERFACE */
 
-static int s_LoadSound(const DXCHAR *filename) {
+static int s_LoadSound(const char *filename) {
     SDL_RWops *rwops;
     char buf[4];
     int soundID;
@@ -766,11 +766,11 @@ static int s_WaitForSound(int soundID) {
     return playing;
 }
 
-int PL_LoadSoundMem(const DXCHAR *filename) {
+int PL_LoadSoundMem(const char *filename) {
     return s_LoadSound(filename);
 }
 
-int PL_LoadSoundMem2(const DXCHAR *filenameA, const DXCHAR *filenameB) {
+int PL_LoadSoundMem2(const char *filenameA, const char *filenameB) {
     int soundIDA = s_LoadSound(filenameA);
     
     if (soundIDA >= 0) {

--- a/src/PL/PLFile.c
+++ b/src/PL/PLFile.c
@@ -249,7 +249,7 @@ void PL_File_SetOpenReadFunction(PLFileOpenFileFunction func) {
     s_openReadFunction = func;
 }
 
-int PL_File_OpenRead(const DXCHAR *filename) {
+int PL_File_OpenRead(const char *filename) {
     if (s_openReadFunction != NULL) {
         return s_openReadFunction(filename);
     } else {
@@ -291,8 +291,10 @@ int PL_File_End() {
     while ((fileHandle = PL_Handle_GetFirstIDOf(DXHANDLE_PLFILE)) >= 0) {
         PL_File_Close(fileHandle);
     }
-    
+
+    /*
     s_openReadFunction = NULL;
+     */
     
     return 0;
 }

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -49,7 +49,7 @@ extern int PL_Platform_GetTicks();
 extern void PL_Platform_Wait(int ticks);
 extern int PL_Platform_GetDateTime(DATEDATA *dateBuf);
 
-extern int PL_Platform_FileOpenReadDirect(const DXCHAR *filename);
+extern int PL_Platform_FileOpenReadDirect(const char *filename);
 extern int PL_Platform_GetSaveFolder(char *buffer, int bufferLength,
                                      const char *org, const char *app,
                                      int destEncoding);
@@ -107,6 +107,12 @@ extern int PL_Text_ConvertStrncat(char *dest, int destCharset,
 
 extern int PL_Text_WideCharToString(char *dest, int charset, const wchar_t *srcStr, int bufSize); 
 extern int PL_Text_StringToWideChar(wchar_t *dest, const char *srcStr, int charset, int bufSize);
+
+extern int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args);
+extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
+                              const wchar_t *format, va_list args);
+extern int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args);
+extern int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args);
 
 #define DXVSNPRINTF SDL_vsnprintf
 

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -50,83 +50,65 @@ extern void PL_Platform_Wait(int ticks);
 extern int PL_Platform_GetDateTime(DATEDATA *dateBuf);
 
 extern int PL_Platform_FileOpenReadDirect(const DXCHAR *filename);
-extern int PL_Platform_GetSaveFolder(DXCHAR *buffer, int bufferLength,
-                                     const DXCHAR *org, const DXCHAR *app,
+extern int PL_Platform_GetSaveFolder(char *buffer, int bufferLength,
+                                     const char *org, const char *app,
                                      int destEncoding);
+
+extern int PL_Platform_MessageBoxError(const char *title, const char *text);
+extern int PL_Platform_MessageBoxYesNo(const char *title, const char *text,
+                                       const char *yes, const char *no);
 
 /* -------------------------------------------------------------- Text.c */
 /* Read functions automatically advance the string pointed to.
  * Write functions return the number of bytes written.
  */
-#ifdef UNICODE
-extern unsigned int PL_Text_ReadUNICODEChar(const wchar_t **textRef);
-extern int PL_Text_WriteUNICODEChar(wchar_t *text, unsigned int ch, int maxLen);
-#endif
+
+extern int PL_Text_ToCharset(int charset);
 
 extern unsigned int PL_Text_ReadUTF8Char(const char **textRef);
-extern int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int maxLen);
+extern int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int bufSize);
+extern int PL_Text_IsIncompleteUTF8Char(const char *string, int length);
 
 #ifndef DXPORTLIB_NON_SJIS
 extern unsigned int PL_Text_ToSJIS(int ch);
 extern unsigned int PL_Text_ReadSJISChar(const char **textRef);
-extern int PL_Text_WriteSJISChar(char *buffer, unsigned int ch, int maxLen);
+extern int PL_Text_WriteSJISChar(char *buffer, unsigned int ch, int bufSize);
+extern int PL_Text_IsIncompleteSJISChar(const char *string, int length);
 #endif /* #ifndef DXPORTLIB_NON_SJIS */
 
-extern unsigned int PL_Text_ReadDxChar(const DXCHAR **textRef);
-extern int PL_Text_WriteDxChar(DXCHAR *textRef, unsigned int ch, int maxLen);
-extern unsigned int PL_Text_ReadChar(const char **textRef, int charset);
-extern int PL_Text_WriteChar(char *buffer, unsigned int ch, int maxLen, int charset);
-
-extern unsigned int PL_Text_SJISToUnicode(unsigned int sjis);
-extern unsigned int PL_Text_UnicodeToSJIS(unsigned int unicode);
-
-extern int PL_Text_ConvertString(const char *inString, char *outBuffer, int maxLen,
-                                int srcCharset, int destCharset);
-
-extern int PL_Text_DxStringToString(const DXCHAR *inString, char *outBuffer, int maxLen, int charset);
-extern int PL_Text_StringToDxString(const char *inString, DXCHAR *outBuffer, int maxLen, int charset);
-
-extern int PL_Text_DxStrlen(const DXCHAR *str);
-extern DXCHAR *PL_Text_DxStrdup(const DXCHAR *str);
-extern void PL_Text_DxStrncat(DXCHAR *str, const DXCHAR *catStr, int maxLen);
-extern void PL_Text_DxStrncpy(DXCHAR *str, const DXCHAR *srcStr, int maxLen);
-extern int PL_Text_DxStrcmp(const DXCHAR *strA, const DXCHAR *strB);
-extern int PL_Text_DxStrcasecmp(const DXCHAR *strA, const DXCHAR *strB);
-extern int PL_Text_DxStrncmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen);
-extern int PL_Text_DxStrncasecmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen);
-extern const DXCHAR *PL_Text_DxStrstr(const DXCHAR *strA, const DXCHAR *strB);
-extern const DXCHAR *PL_Text_DxStrcasestr(const DXCHAR *strA, const DXCHAR *strB);
-extern int PL_Text_DxStrTestExt(const DXCHAR *str, const DXCHAR *ext);
-
-extern void PL_Text_DxStrncatFromString(DXCHAR *str, const char *catStr, int maxLen, int charset);
-extern void PL_Text_DxStrncpyFromString(DXCHAR *str, const char *srcStr, int maxLen, int charset);
-
-extern int PL_Text_IsIncompleteSJISChar(const char *string, int length);
-extern int PL_Text_IsIncompleteUTF8Char(const char *string, int length);
 extern int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset);
-extern int PL_Text_SetUseCharSet(int charset);
-extern int PL_Text_GetUseCharSet();
 
-#define DXSTRLEN(str) PL_Text_DxStrlen(str)
-#define DXSTRDUP(str) PL_Text_DxStrdup(str)
-#define DXSTRNCPY(str, catStr, maxLen) PL_Text_DxStrncpy(str, catStr, maxLen)
-#define DXSTRNCAT(str, srcStr, maxLen) PL_Text_DxStrncat(str, srcStr, maxLen)
-#define DXSTRCMP(strA, strB) PL_Text_DxStrcmp(strA, strB)
-#define DXSTRCASECMP(strA, strB) PL_Text_DxStrcasecmp(strA, strB)
-#define DXSTRNCMP(strA, strB, len) PL_Text_DxStrncmp(strA, strB, len)
-#define DXSTRNCASECMP(strA, strB, len) PL_Text_DxStrncasecmp(strA, strB, len)
-#define DXSTRSTR(strA, strB) PL_Text_DxStrstr(strA, strB)
-#define DXSTRCASESTR(strA, strB) PL_Text_DxStrcasestr(strA, strB)
-#define DXSTRTESTEXT(str, ext) PL_Text_DxStrTestExt(str, ext)
+extern unsigned int PL_Text_ReadChar(const char **textRef, int charset);
+extern int PL_Text_WriteChar(char *buffer, unsigned int ch, int bufSize, int charset);
 
-#define DXSTRNCATFROMSTR(str, catStr, maxLen, charset) PL_Text_DxStrncatFromString(str, catStr, maxLen, charset)
-#define DXSTRNCPYFROMSTR(str, srcStr, maxLen, charset) PL_Text_DxStrncpyFromString(str, srcStr, maxLen, charset)
+extern int PL_Text_Strlen(const char *dest);
+extern char *PL_Text_Strdup(const char *dest);
+extern int PL_Text_Strncat(char *dest, const char *srcStr, int bufSize);
+extern int PL_Text_Strncpy(char *dest, const char *srcStr, int bufSize);
+extern int PL_Text_Strcmp(const char *strA, const char *strB);
+extern int PL_Text_Strcasecmp(const char *strA, const char *strB);
+extern int PL_Text_Strncmp(const char *strA, const char *strB, int bufSize);
+extern int PL_Text_Strncasecmp(const char *strA, const char *strB, int bufSize);
+extern const char *PL_Text_Strstr(const char *strA, const char *strB);
+extern const char *PL_Text_Strcasestr(const char *strA, const char *strB);
+extern int PL_Text_StrTestExt(const char *str, const char *ext);
 
-#ifdef UNICODE
-#define DXVSNPRINTF vswprintf
-#else
+extern int PL_Text_ConvertStrncpy(char *dest, int destCharset,
+                                 const char *src, int srcCharset,
+                                 int bufSize);
+extern const char *PL_Text_ConvertStrncpyIfNecessary(
+                                 char *dest, int destCharset,
+                                 const char *src, int srcCharset,
+                                 int bufSize);
+
+extern int PL_Text_ConvertStrncat(char *dest, int destCharset,
+                                  const char *srcStr, int srcCharset,
+                                  int bufSize);
+
+extern int PL_Text_WideCharToString(char *dest, int charset, const wchar_t *srcStr, int bufSize); 
+extern int PL_Text_StringToWideChar(wchar_t *dest, const char *srcStr, int charset, int bufSize);
+
 #define DXVSNPRINTF SDL_vsnprintf
-#endif
 
 /* ------------------------------------------------------------ Handle.c */
 typedef enum {
@@ -173,7 +155,7 @@ extern int PL_Handle_GetNextID(int handleID);
 extern int PL_Handle_SetDeleteFlag(int handleID, int *deleteFlag);
 
 /* ------------------------------------------------------------ File.c */
-typedef int (*PLFileOpenFileFunction)(const DXCHAR *filename);
+typedef int (*PLFileOpenFileFunction)(const char *filename);
 
 typedef struct _PL_FileFunctions {
     int64_t (*getSize)(void *userdata);
@@ -184,7 +166,7 @@ typedef struct _PL_FileFunctions {
 } PL_FileFunctions;
 
 extern void PL_File_SetOpenReadFunction(PLFileOpenFileFunction func);
-extern int PL_File_OpenRead(const DXCHAR *filename);
+extern int PL_File_OpenRead(const char *filename);
 extern int PL_File_CreateHandle(const PL_FileFunctions *funcs, void *userdata);
 extern int PL_File_CreateHandleFromMemory(void *data, int length, int freeOnClose);
 extern int PL_File_CreateHandleSubsection(int srcFileHandle,
@@ -211,7 +193,7 @@ extern int PL_Window_ProcessMessages();
 
 extern int PL_Window_SetFullscreen(int isFullscreen, int fullscreenDesktop);
 extern int PL_Window_SetDimensions(int width, int height, int colorDepth, int refreshRate);
-extern int PL_Window_SetTitle(const DXCHAR *titleString);
+extern int PL_Window_SetTitle(const char *titleString);
 
 extern int PL_Window_SetWindowResizeFlag(int flag);
 extern int PL_Window_ChangeOnlyWindowSize(int width, int height);
@@ -234,11 +216,7 @@ extern int PL_Window_GetAlwaysRunFlag();
 extern int PL_Window_GetActiveFlag();
 extern int PL_Window_GetWindowModeFlag();
 
-extern int PLEXT_Window_SetIconImageFile(const DXCHAR *filename);
-
-extern int PLEXT_Window_MessageBoxError(const DXCHAR *title, const DXCHAR *text);
-extern int PLEXT_Window_MessageBoxYesNo(const DXCHAR *title, const DXCHAR *text,
-                                        const DXCHAR *yes, const DXCHAR *no);
+extern int PL_Window_SetIconFromFile(const char *filename);
 
 extern int PL_Window_BindMainFramebuffer();
 extern int PL_Window_GetFramebuffer();
@@ -500,7 +478,7 @@ extern int PL_Surface_FlipSurface(int surfaceID);
 extern int PL_Surface_GetSize(int surfaceID, int *w, int *h);
 extern int PL_Surface_HasTransparency(int surfaceID);
 
-extern int PL_Surface_Load(const DXCHAR *filename);
+extern int PL_Surface_Load(const char *filename);
 extern int PL_Surface_Delete(int surfaceID);
 
 extern int PL_Surface_ToTexture(int surfaceID);
@@ -511,79 +489,14 @@ extern void PL_Surface_End();
 
 /* -------------------------------------------------------- SaveScreen.c */
 extern int PL_SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                                  const DXCHAR *filename);
+                                  const char *filename);
 extern int PL_SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                                   const DXCHAR *filename,
+                                   const char *filename,
                                    int quality, int sample2x1);
 extern int PL_SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                                  const DXCHAR *filename,
+                                  const char *filename,
                                   int compressionLevel);
 
-/* -------------------------------------------------------------- Font.c */
-/* Handle font functions */
-extern int PL_Font_DrawStringToHandle(int x, int y, const DXCHAR *string,
-                                      DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
-extern int PL_Font_DrawFormatStringToHandle(int x, int y, DXCOLOR color, int fontHandle,
-                                            const DXCHAR *string, va_list args);
-extern int PL_Font_DrawExtendStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                                            const DXCHAR *string,
-                                            DXCOLOR color, int fontHandle, DXCOLOR edgeColor);
-extern int PL_Font_DrawExtendFormatStringToHandle(int x, int y, double ExRateX, double ExRateY,
-                                                  DXCOLOR color, int fontHandle,
-                                                  const DXCHAR *string, va_list args);
-
-extern int PL_Font_GetDrawStringWidthToHandle(const DXCHAR *string, int strLen, int fontHandle);
-extern int PL_Font_GetDrawFormatStringWidthToHandle(int fontHandle, const DXCHAR *string, va_list args);
-extern int PL_Font_GetDrawExtendStringWidthToHandle(double ExRateX, const DXCHAR *string, int strLen, int fontHandle);
-extern int PL_Font_GetDrawExtendFormatStringWidthToHandle(double ExRateX, int fontHandle, const DXCHAR *string, va_list args);
-
-extern int PL_Font_GetFontSizeToHandle(int fontHandle);
-extern int PL_Font_GetFontCharInfo(int fontHandle, const DXCHAR *string,
-                              int *xPos, int *yPos, int *advanceX, int *width, int *height);
-extern int PL_Font_SetFontSpaceToHandle(int fontSpacing, int fontHandle);
-
-extern int PL_Font_CreateFontToHandle(const DXCHAR *fontname,
-                                 int size, int thickness, int fontType, int charset,
-                                 int edgeSize, int italic
-                                );
-extern int PL_Font_DeleteFontToHandle(int handle);
-extern int PL_Font_CheckFontHandleValid(int fontHandle);
-extern int PL_Font_SetFontLostFlag(int fontHandle, int *lostFlag);
-
-extern int PL_Font_InitFontToHandle();
-
-/* "Default" font functions */
-extern int PL_Font_DrawString(int x, int y, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
-extern int PL_Font_DrawFormatString(int x, int y, DXCOLOR color, const DXCHAR *string, va_list args);
-extern int PL_Font_DrawExtendString(int x, int y, double ExRateX, double ExRateY, const DXCHAR *string, DXCOLOR color, DXCOLOR edgeColor);
-extern int PL_Font_DrawExtendFormatString(int x, int y, double ExRateX, double ExRateY, DXCOLOR color, const DXCHAR *string, va_list args);
-extern int PL_Font_GetDrawStringWidth(const DXCHAR *string, int strLen);
-extern int PL_Font_GetDrawFormatStringWidth(const DXCHAR *string, va_list args);
-extern int PL_Font_GetDrawExtendStringWidth(double ExRateX, const DXCHAR *string, int strLen);
-extern int PL_Font_GetDrawExtendFormatStringWidth(double ExRateX, const DXCHAR *string, va_list args);
-
-extern int PL_Font_ChangeFont(const DXCHAR *string, int charSet);
-extern int PL_Font_ChangeFontType(int fontType);
-extern int PL_Font_SetFontSize(int fontSize);
-extern int PL_Font_GetFontSize();
-extern int PL_Font_SetFontThickness(int fontThickness);
-extern int PL_Font_SetFontSpace(int fontSpace);
-extern int PL_Font_SetDefaultFontState(const DXCHAR *fontName, int fontSize, int fontThickness);
-extern int PL_Font_GetDefaultFontHandle();
-
-/* Font mappings and upkeep. */
-extern int PLEXT_Font_MapFontFileToName(const DXCHAR *filename,
-                                   const DXCHAR *fontname,
-                                   int thickness, int boldFlag,
-                                   double exRateX, double exRateY
-                                  );
-extern int PLEXT_Font_InitFontMappings();
-
-extern void PL_Font_Init();
-extern void PL_Font_End();
-
-extern int PL_Font_SetFontCacheUsePremulAlphaFlag(int flag);
-extern int PL_Font_GetFontCacheUsePremulAlphaFlag();
 
 /* --------------------------------------------------------------- Input.c */
 #ifndef DX_NON_INPUT
@@ -639,8 +552,8 @@ extern int PL_Random_SeedLuna(int randomSeed);
 /* --------------------------------------------------------------- Audio.c */
 #ifndef DX_NON_SOUND
 
-extern int PL_LoadSoundMem(const DXCHAR *filename);
-extern int PL_LoadSoundMem2(const DXCHAR *filenameA, const DXCHAR *filenameB);
+extern int PL_LoadSoundMem(const char *filename);
+extern int PL_LoadSoundMem2(const char *filenameA, const char *filenameB);
 extern int PL_DeleteSoundMem(int soundID);
 extern int PL_PlaySoundMem(int soundID, int playType, int startPositionFlag);
 extern int PL_StopSoundMem(int soundID);

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -125,7 +125,9 @@ extern void PL_Text_StrUpperW(wchar_t *str);
 extern void PL_Text_StrLowerW(wchar_t *str);
 
 extern int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args);
+extern int PL_Text_Snprintf(char *dest, int bufSize, int charset, const char *format, ...);
 extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, va_list args);
+extern int PL_Text_Wsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, ...);
 extern int PL_Text_Vsscanf(const char *str, int charset, const char *format, va_list args);
 extern int PL_Text_Wvsscanf(const wchar_t *str, int charset, const wchar_t *format, va_list args);
 

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -13,7 +13,7 @@
   1. The origin of this software must not be misrepresented; you must not
      claim that you wrote the original software. If you use this software
      in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required. 
+     appreciated but is not required.
   2. Altered source versions must be plainly marked as such, and must not be
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include "SDL.h"
 
-#ifdef __cplusplus   
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -82,16 +82,27 @@ extern unsigned int PL_Text_ReadChar(const char **textRef, int charset);
 extern int PL_Text_WriteChar(char *buffer, unsigned int ch, int bufSize, int charset);
 
 extern int PL_Text_Strlen(const char *dest);
+extern int PL_Text_StrlenW(const wchar_t *dest);
 extern char *PL_Text_Strdup(const char *dest);
+extern wchar_t *PL_Text_StrdupW(const wchar_t *dest);
 extern int PL_Text_Strncat(char *dest, const char *srcStr, int bufSize);
+extern int PL_Text_StrncatW(wchar_t *dest, const wchar_t *srcStr, int bufSize);
 extern int PL_Text_Strncpy(char *dest, const char *srcStr, int bufSize);
+extern int PL_Text_StrncpyW(wchar_t *str, const wchar_t *cpyStr, int bufSize);
 extern int PL_Text_Strcmp(const char *strA, const char *strB);
+extern int PL_Text_StrcmpW(const wchar_t *strA, const wchar_t *strB);
 extern int PL_Text_Strcasecmp(const char *strA, const char *strB);
+extern int PL_Text_StrcasecmpW(const wchar_t *strA, const wchar_t *strB);
 extern int PL_Text_Strncmp(const char *strA, const char *strB, int bufSize);
+extern int PL_Text_StrncmpW(const wchar_t *strA, const wchar_t *strB, int bufSize);
 extern int PL_Text_Strncasecmp(const char *strA, const char *strB, int bufSize);
+extern int PL_Text_StrncasecmpW(const wchar_t *strA, const wchar_t *strB, int bufSize);
 extern const char *PL_Text_Strstr(const char *strA, const char *strB);
+extern const wchar_t *PL_Text_StrstrW(const wchar_t *strA, const wchar_t *strB);
 extern const char *PL_Text_Strcasestr(const char *strA, const char *strB);
+extern const wchar_t *PL_Text_StrcasestrW(const wchar_t *strA, const wchar_t *strB);
 extern int PL_Text_StrTestExt(const char *str, const char *ext);
+extern int PL_Text_StrTestExtW(const wchar_t *str, const wchar_t *ext);
 
 extern int PL_Text_ConvertStrncpy(char *dest, int destCharset,
                                  const char *src, int srcCharset,
@@ -105,12 +116,16 @@ extern int PL_Text_ConvertStrncat(char *dest, int destCharset,
                                   const char *srcStr, int srcCharset,
                                   int bufSize);
 
-extern int PL_Text_WideCharToString(char *dest, int charset, const wchar_t *srcStr, int bufSize); 
+extern int PL_Text_WideCharToString(char *dest, int charset, const wchar_t *srcStr, int bufSize);
 extern int PL_Text_StringToWideChar(wchar_t *dest, const char *srcStr, int charset, int bufSize);
 
+extern void PL_Text_StrUpper(char *str, int charset);
+extern void PL_Text_StrLower(char *str, int charset);
+extern void PL_Text_StrUpperW(wchar_t *str);
+extern void PL_Text_StrLowerW(wchar_t *str);
+
 extern int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args);
-extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
-                              const wchar_t *format, va_list args);
+extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, va_list args);
 extern int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args);
 extern int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args);
 

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -126,10 +126,8 @@ extern void PL_Text_StrLowerW(wchar_t *str);
 
 extern int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args);
 extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, va_list args);
-extern int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args);
-extern int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args);
-
-#define DXVSNPRINTF SDL_vsnprintf
+extern int PL_Text_Vsscanf(const char *str, int charset, const char *format, va_list args);
+extern int PL_Text_Wvsscanf(const wchar_t *str, int charset, const wchar_t *format, va_list args);
 
 /* ------------------------------------------------------------ Handle.c */
 typedef enum {

--- a/src/PL/PLInternal.h
+++ b/src/PL/PLInternal.h
@@ -129,7 +129,9 @@ extern int PL_Text_Snprintf(char *dest, int bufSize, int charset, const char *fo
 extern int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, va_list args);
 extern int PL_Text_Wsnprintf(wchar_t *dest, int bufSize, int charset, const wchar_t *format, ...);
 extern int PL_Text_Vsscanf(const char *str, int charset, const char *format, va_list args);
+extern int PL_Text_Sscanf(const char *str, int charset, const char *format, ...);
 extern int PL_Text_Wvsscanf(const wchar_t *str, int charset, const wchar_t *format, va_list args);
+extern int PL_Text_Wsscanf(const wchar_t *str, int charset, const wchar_t *format, ...);
 
 /* ------------------------------------------------------------ Handle.c */
 typedef enum {

--- a/src/PL/PLSurface.c
+++ b/src/PL/PLSurface.c
@@ -259,7 +259,7 @@ int PL_Surface_FlipSurface(int surfaceID) {
     return DXTRUE;
 }
 
-int PL_Surface_Load(const DXCHAR *filename) {
+int PL_Surface_Load(const char *filename) {
     SDL_RWops *file;
     SDL_Surface *sdlSurface;
     int surfaceID;
@@ -275,7 +275,7 @@ int PL_Surface_Load(const DXCHAR *filename) {
     sdlSurface = IMG_Load_RW(file, SDL_FALSE);
     if (sdlSurface == NULL) {
         /* Get around an SDL2_image bug */
-        if (DXSTRTESTEXT(filename, TEXT(".tga"))) {
+        if (PL_Text_StrTestExt(filename, TEXT(".tga"))) {
             sdlSurface = IMG_LoadTGA_RW(file);
         }
     }

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -456,6 +456,9 @@ int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset) {
     }
 }
 
+/* Not all platforms have these, so we implement our own, with custom
+ * locale support. Suffering. */
+
 int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args) {
     return 0;
 }

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -184,9 +184,9 @@ int PL_Text_ToCharset(int charset) {
     }
 }
 
-int PL_Text_ConvertString(const char *srcStr, int srcCharset,
-                          char *dest, int destCharset,
-                          int bufSize) {
+int PL_Text_ConvertStrncpy(char *dest, int destCharset,
+                           const char *srcStr, int srcCharset,
+                           int bufSize) {
     unsigned int ch;
     int count = 0;
     
@@ -212,7 +212,7 @@ int PL_Text_ConvertString(const char *srcStr, int srcCharset,
     return count;
 }
 
-const char *PL_Text_ConvertStringIfNecessary(
+const char *PL_Text_ConvertStrncpyIfNecessary(
             char *dest, int destCharset,
             const char *srcStr, int srcCharset,
             int bufSize) {

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -125,7 +125,7 @@ int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int bufSize) {
         }
     }
     
-    return 0;    
+    return 0;
 }
 
 int PL_Text_IsIncompleteUTF8Char(const char *buffer, int length) {
@@ -306,6 +306,10 @@ int PL_Text_Strncat(char *str, const char *catStr, int bufSize) {
     }
     
     bufSize -= 1;
+    
+    while (str[count] != 0 && count < bufSize) {
+        count += 1;
+    }
     
     while (count < bufSize && (ch = (*catStr++)) != 0) {
         str[count++] = ch;

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -13,7 +13,7 @@
   1. The origin of this software must not be misrepresented; you must not
      claim that you wrote the original software. If you use this software
      in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required. 
+     appreciated but is not required.
   2. Altered source versions must be plainly marked as such, and must not be
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
@@ -283,6 +283,15 @@ int PL_Text_Strlen(const char *str) {
     
     return i;
 }
+int PL_Text_StrlenW(const wchar_t *str) {
+    int i = 0;
+    
+    while (str[i] != 0) {
+        ++i;
+    }
+    
+    return i;
+}
 
 char *PL_Text_Strdup(const char *str) {
     int len = PL_Text_Strlen(str);
@@ -296,10 +305,43 @@ char *PL_Text_Strdup(const char *str) {
     
     return dest;
 }
+wchar_t *PL_Text_StrdupW(const wchar_t *str) {
+    int len = PL_Text_StrlenW(str);
+    wchar_t *dest = (wchar_t *)DXALLOC((unsigned int)(len + 1) * sizeof(wchar_t));
+    int i;
+    
+    for (i = 0; i < len; ++i) {
+        dest[i] = str[i];
+    }
+    dest[len] = 0;
+    
+    return dest;
+}
 
 int PL_Text_Strncat(char *str, const char *catStr, int bufSize) {
     int count = 0;
     char ch;
+    
+    if (bufSize <= 0) {
+        return 0;
+    }
+    
+    bufSize -= 1;
+    
+    while (str[count] != 0 && count < bufSize) {
+        count += 1;
+    }
+    
+    while (count < bufSize && (ch = (*catStr++)) != 0) {
+        str[count++] = ch;
+    }
+    
+    str[count] = 0;
+    return count;
+}
+int PL_Text_StrncatW(wchar_t *str, const wchar_t *catStr, int bufSize) {
+    int count = 0;
+    wchar_t ch;
     
     if (bufSize <= 0) {
         return 0;
@@ -336,6 +378,23 @@ int PL_Text_Strncpy(char *str, const char *cpyStr, int bufSize) {
     str[count] = 0;
     return count;
 }
+int PL_Text_StrncpyW(wchar_t *str, const wchar_t *cpyStr, int bufSize) {
+    int count = 0;
+    wchar_t ch;
+    
+    if (bufSize <= 0) {
+        return 0;
+    }
+    
+    bufSize -= 1;
+    
+    while (count < bufSize && (ch = (*cpyStr++)) != 0) {
+        str[count++] = ch;
+    }
+    
+    str[count] = 0;
+    return count;
+}
 
 int PL_Text_ConvertStrncat(char *dest, int destCharset, const char *srcStr, int srcCharset, int bufSize) {
     int len = PL_Text_Strlen(dest);
@@ -344,6 +403,16 @@ int PL_Text_ConvertStrncat(char *dest, int destCharset, const char *srcStr, int 
 }
 
 int PL_Text_Strcmp(const char *strA, const char *strB) {
+    int v;
+    
+    while ((v = (*strB - *strA)) == 0 && *strA != 0) {
+        strA += 1;
+        strB += 1;
+    }
+    
+    return v;
+}
+int PL_Text_StrcmpW(const wchar_t *strA, const wchar_t *strB) {
     int v;
     
     while ((v = (*strB - *strA)) == 0 && *strA != 0) {
@@ -374,6 +443,28 @@ int PL_Text_Strcasecmp(const char *strA, const char *strB) {
     
     return v;
 }
+int PL_Text_StrcasecmpW(const wchar_t *strA, const wchar_t *strB) {
+    unsigned int a, b;
+    int v;
+    
+    do {
+        a = *strA++;
+        b = *strB++;
+        v = b - a;
+        if (v != 0) {
+            if (a >= 'A' && a <= 'Z') {
+                a += 'a' - 'A';
+            }
+            if (b >= 'A' && b <= 'Z') {
+                b += 'a' - 'A';
+            }
+            v = b - a;
+        }
+    } while (v == 0 && a != 0 && b != 0);
+    
+    return v;
+}
+
 int PL_Text_Strncmp(const char *strA, const char *strB, int bufSize) {
     int v = 0;
     const char *end = strA + bufSize;
@@ -385,6 +476,18 @@ int PL_Text_Strncmp(const char *strA, const char *strB, int bufSize) {
     
     return v;
 }
+int PL_Text_StrncmpW(const wchar_t *strA, const wchar_t *strB, int bufSize) {
+    int v = 0;
+    const wchar_t *end = strA + bufSize;
+    
+    while (strA < end && (v = (*strB - *strA)) == 0 && *strA != 0) {
+        strA += 1;
+        strB += 1;
+    }
+    
+    return v;
+}
+
 int PL_Text_Strncasecmp(const char *strA, const char *strB, int bufSize) {
     const char *endA = strA + bufSize;
     unsigned int a, b;
@@ -407,6 +510,29 @@ int PL_Text_Strncasecmp(const char *strA, const char *strB, int bufSize) {
     
     return v;
 }
+int PL_Text_StrncasecmpW(const wchar_t *strA, const wchar_t *strB, int bufSize) {
+    const wchar_t *endA = strA + bufSize;
+    unsigned int a, b;
+    int v;
+    
+    do {
+        a = *strA++;
+        b = *strB++;
+        v = b - a;
+        if (v != 0) {
+            if (a >= 'A' && a <= 'Z') {
+                a += 'a' - 'A';
+            }
+            if (b >= 'A' && b <= 'Z') {
+                b += 'a' - 'A';
+            }
+            v = b - a;
+        }
+    } while (v == 0 && a != 0 && b != 0 && strA < endA);
+    
+    return v;
+}
+
 const char *PL_Text_Strstr(const char *strA, const char *strB) {
     int n = PL_Text_Strlen(strB);
     while (*strA) {
@@ -417,6 +543,16 @@ const char *PL_Text_Strstr(const char *strA, const char *strB) {
     }
     return NULL;
 }
+const wchar_t *PL_Text_StrstrW(const wchar_t *strA, const wchar_t *strB) {
+    int n = PL_Text_StrlenW(strB);
+    while (*strA) {
+        if (!PL_Text_StrncmpW(strA, strB, n)) {
+            return strA;
+        }
+        strA += 1;
+    }
+    return NULL;
+}
 const char *PL_Text_Strcasestr(const char *strA, const char *strB) {
     int n = PL_Text_Strlen(strB);
     while (*strA) {
@@ -424,6 +560,16 @@ const char *PL_Text_Strcasestr(const char *strA, const char *strB) {
             return strA;
         }
         PL_Text_ReadUTF8Char(&strA);
+    }
+    return NULL;
+}
+const wchar_t *PL_Text_StrcasestrW(const wchar_t *strA, const wchar_t *strB) {
+    int n = PL_Text_StrlenW(strB);
+    while (*strA) {
+        if (!PL_Text_StrncasecmpW(strA, strB, n)) {
+            return strA;
+        }
+        strA += 1;
     }
     return NULL;
 }
@@ -448,6 +594,69 @@ int PL_Text_StrTestExt(const char *str, const char *ext) {
     }
     return DXFALSE;
 }
+int PL_Text_StrTestExtW(const wchar_t *str, const wchar_t *ext) {
+    int slen = PL_Text_StrlenW(str);
+    int elen = PL_Text_StrlenW(ext);
+    const wchar_t *target = str + slen - elen;
+    
+    if (slen < elen) {
+        return DXFALSE;
+    }
+    
+    if (PL_Text_StrcasecmpW(target, ext) == 0) {
+        return DXTRUE;
+    }
+    return DXFALSE;
+}
+
+void PL_Text_StrUpper(char *str, int charset) {
+    unsigned int a;
+    
+    do {
+        char *dest = str;
+        a = PL_Text_ReadChar((const char **)&str, charset);
+        
+        if (a >= 'a' && a <= 'z') {
+            a += 'A' - 'a';
+            *dest = a; /* Assumes always one char. */
+        }
+    } while (a != 0);
+}
+
+void PL_Text_StrLower(char *str, int charset) {
+    unsigned int a;
+    
+    do {
+        char *dest = str;
+        a = PL_Text_ReadChar((const char **)&str, charset);
+        if (a >= 'A' && a <= 'Z') {
+            a += 'a' - 'A';
+            *dest = a; /* Assumes always one char. */
+        }
+    } while (a != 0);
+}
+
+void PL_Text_StrUpperW(wchar_t *str) {
+    unsigned int a;
+    
+    while ((a = *str++) != 0) {
+        if (a >= 'a' && a <= 'z') {
+            a += 'A' - 'a';
+            str[-1] = a;
+        }
+    }
+}
+
+void PL_Text_StrLowerW(wchar_t *str) {
+    unsigned int a;
+    
+    while ((a = *str++) != 0) {
+        if (a >= 'A' && a <= 'Z') {
+            a += 'a' - 'A';
+            str[-1] = a;
+        }
+    }
+}
 
 int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset) {
     switch(charset) {
@@ -460,19 +669,3 @@ int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset) {
     }
 }
 
-/* Not all platforms have these, so we implement our own, with custom
- * locale support. Suffering. */
-
-int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args) {
-    return 0;
-}
-int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
-                       const wchar_t *format, va_list args) {
-    return 0;
-}
-int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args) {
-    return 0;
-}
-int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args) {
-    return 0;
-}

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -455,3 +455,17 @@ int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset) {
             return PL_Text_IsIncompleteUTF8Char(string, length);
     }
 }
+
+int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args) {
+    return 0;
+}
+int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
+                       const wchar_t *format, va_list args) {
+    return 0;
+}
+int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args) {
+    return 0;
+}
+int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args) {
+    return 0;
+}

--- a/src/PL/PLText.c
+++ b/src/PL/PLText.c
@@ -21,7 +21,7 @@
 
 #include "PLInternal.h"
 
-static int s_useCharSet = DX_CHARSET_EXT_UTF8;
+static const int s_defaultCharset = DX_CHARSET_EXT_UTF8;
 
 unsigned int PL_Text_ReadUTF8Char(const char **textRef) {
     const unsigned char *text = (const unsigned char *)*textRef;
@@ -71,22 +71,22 @@ unsigned int PL_Text_ReadUTF8Char(const char **textRef) {
     return value;
 }
 
-int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int maxLen) {
+int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int bufSize) {
     if (ch < 0x80) {
-        if (maxLen >= 1) {
+        if (bufSize >= 1) {
             buffer[0] = (char)ch;
         
             return 1;
         }
     } else if (ch < 0x800) {
-        if (maxLen >= 2) {
+        if (bufSize >= 2) {
             buffer[0] = (char)(0xc0 | ((ch >> 6) & 0x1f));
             buffer[1] = (char)(0x80 | (ch & 0x3f));
             
             return 2;
         }
     } else if (ch < 0x10000) {
-        if (maxLen >= 3) {
+        if (bufSize >= 3) {
             buffer[0] = (char)(0xe0 | ((ch >> 12) & 0x0f));
             buffer[1] = (char)(0x80 | ((ch >> 6) & 0x3f));
             buffer[2] = (char)(0x80 | (ch & 0x3f));
@@ -94,7 +94,7 @@ int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int maxLen) {
             return 3;
         }
     } else if (ch < 0x200000) {
-        if (maxLen >= 4) {
+        if (bufSize >= 4) {
             buffer[0] = (char)(0xf0 | ((ch >> 18) & 0x07));
             buffer[1] = (char)(0x80 | ((ch >> 12) & 0x3f));
             buffer[2] = (char)(0x80 | ((ch >> 6) & 0x3f));
@@ -103,7 +103,7 @@ int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int maxLen) {
             return 4;
         }
     } else if (ch < 0x4000000) {
-        if (maxLen >= 5) {
+        if (bufSize >= 5) {
             buffer[0] = (char)(0xf8 | ((ch >> 24) & 0x03));
             buffer[1] = (char)(0x80 | ((ch >> 18) & 0x3f));
             buffer[2] = (char)(0x80 | ((ch >> 12) & 0x3f));
@@ -113,7 +113,7 @@ int PL_Text_WriteUTF8Char(char *buffer, unsigned int ch, int maxLen) {
             return 5;
         }
     } else {
-        if (maxLen >= 6) {
+        if (bufSize >= 6) {
             buffer[0] = (char)(0xfc | ((ch >> 30) & 0x01));
             buffer[1] = (char)(0x80 | ((ch >> 24) & 0x3f));
             buffer[2] = (char)(0x80 | ((ch >> 18) & 0x3f));
@@ -155,110 +155,126 @@ unsigned int PL_Text_ReadChar(const char **textRef, int charset) {
         case DX_CHARSET_SHFTJIS:
             return PL_Text_ReadSJISChar(textRef);
 #endif /* #ifndef DXPORTLIB_NON_SJIS */
-        case DX_CHARSET_EXT_UTF8:
+        default: /* case DX_CHARSET_EXT_UTF8: */
             return PL_Text_ReadUTF8Char(textRef);
-        default:
-            return PL_Text_ReadChar(textRef, s_useCharSet);
     }
 }
 
-int PL_Text_WriteChar(char *text, unsigned int ch, int maxLen, int charset) {
+int PL_Text_WriteChar(char *text, unsigned int ch, int bufSize, int charset) {
     switch(charset) {
 #ifndef DXPORTLIB_NO_SJIS
         case DX_CHARSET_SHFTJIS:
-            return PL_Text_WriteSJISChar(text, ch, maxLen);
+            return PL_Text_WriteSJISChar(text, ch, bufSize);
+#endif /* #ifndef DXPORTLIB_NON_SJIS */
+        default: /* case DX_CHARSET_EXT_UTF8: */
+            return PL_Text_WriteUTF8Char(text, ch, bufSize);
+    }
+}
+
+int PL_Text_ToCharset(int charset) {
+    switch(charset) {
+#ifndef DXPORTLIB_NO_SJIS
+        case DX_CHARSET_SHFTJIS:
+            return DX_CHARSET_SHFTJIS;
 #endif /* #ifndef DXPORTLIB_NON_SJIS */
         case DX_CHARSET_EXT_UTF8:
-            return PL_Text_WriteUTF8Char(text, ch, maxLen);
+            return DX_CHARSET_EXT_UTF8;
         default:
-            return PL_Text_WriteChar(text, ch, maxLen, s_useCharSet);
+            return s_defaultCharset;
     }
 }
 
-#ifdef UNICODE
-unsigned int PL_Text_ReadUNICODEChar(const wchar_t **textRef) {
-    const wchar_t *text = *textRef;
-    unsigned int ch = *text;
-    
-    *textRef = text + 1;
-    
-    return ch;
-}
-int PL_Text_WriteUNICODEChar(wchar_t *text, unsigned int ch, int maxLen) {
-    if (maxLen >= 1) {
-        *text = ch;
-        return 1;
-    }
-    
-    return 0;
-}
-
-/* DXCHAR is wchar_t */
-unsigned int PL_Text_ReadDxChar(const DXCHAR **textRef) {
-    return PL_Text_ReadUNICODEChar(textRef);
-}
-int PL_Text_WriteDxChar(DXCHAR *text, unsigned int ch, int maxLen) {
-    return PL_Text_WriteUNICODEChar(text, ch, maxLen);
-}
-#else
-/* DXCHAR is CharSet */
-unsigned int PL_Text_ReadDxChar(const DXCHAR **textRef) {
-    return PL_Text_ReadChar((const char **)textRef, s_useCharSet);
-}
-int PL_Text_WriteDxChar(DXCHAR *text, unsigned int ch, int maxLen) {
-    return PL_Text_WriteChar((char *)text, ch, maxLen, s_useCharSet);
-}
-
-#endif
-
-int PL_Text_ConvertString(const char *inString, char *outBuffer, int maxLen,
-                            int srcCharset, int destCharset) {
+int PL_Text_ConvertString(const char *srcStr, int srcCharset,
+                          char *dest, int destCharset,
+                          int bufSize) {
     unsigned int ch;
     int count = 0;
     
-    maxLen -= 1;
-    
-    while (count < maxLen && (ch = PL_Text_ReadChar(&inString, srcCharset)) != 0) {
-        count += PL_Text_WriteChar(outBuffer + count, ch, maxLen - count, destCharset);
+    if (bufSize <= 0) {
+        return 0;
     }
     
-    outBuffer[count] = '\0';
+    srcCharset = PL_Text_ToCharset(srcCharset);
+    destCharset = PL_Text_ToCharset(destCharset);
+    
+    if (srcCharset == destCharset) {
+        return PL_Text_Strncpy(dest, srcStr, bufSize);
+    }
+    
+    bufSize -= 1;
+    
+    while (count < bufSize && (ch = PL_Text_ReadChar(&srcStr, srcCharset)) != 0) {
+        count += PL_Text_WriteChar(dest + count, ch, bufSize - count, destCharset);
+    }
+    
+    dest[count] = '\0';
     
     return count;
 }
 
-/* glorified strcpys go here */
-int PL_Text_DxStringToString(const DXCHAR *inString, char *outBuffer, int maxLen, int charset) {
-    unsigned int ch;
-    int count = 0;
+const char *PL_Text_ConvertStringIfNecessary(
+            char *dest, int destCharset,
+            const char *srcStr, int srcCharset,
+            int bufSize) {
+    srcCharset = PL_Text_ToCharset(srcCharset);
+    destCharset = PL_Text_ToCharset(destCharset);
     
-    maxLen -= 1;
-    
-    while (count < maxLen && (ch = PL_Text_ReadDxChar(&inString)) != 0) {
-        count += PL_Text_WriteChar(outBuffer + count, ch, maxLen - count, charset);
+    if (srcCharset == destCharset) {
+        return srcStr;
     }
     
-    outBuffer[count] = '\0';
+    PL_Text_ConvertStrncpy(dest, destCharset, srcStr, srcCharset, bufSize);
+    
+    return dest;
+}
+
+
+int PL_Text_WideCharToString(char *dest, int charset, const wchar_t *srcStr, int bufSize) {
+    unsigned int ch;
+    int count = 0;
+    int index = 0;
+    
+    if (bufSize <= 0) {
+        return 0;
+    }
+    
+    charset = PL_Text_ToCharset(charset);
+    
+    bufSize -= 1;
+    
+    while (count < bufSize && (ch = srcStr[index]) != 0) {
+        count += PL_Text_WriteChar(dest + count, ch, bufSize - count, charset);
+        index += 1;
+    }
+    
+    dest[count] = '\0';
     
     return count;
 }
 
-int PL_Text_StringToDxString(const char *inString, DXCHAR *outBuffer, int maxLen, int charset) {
+int PL_Text_StringToWideChar(wchar_t *dest, const char *srcStr, int charset, int bufSize) {
     unsigned int ch;
     int count = 0;
     
-    maxLen -= 1;
-    
-    while (count < maxLen && (ch = PL_Text_ReadChar(&inString, charset)) != 0) {
-        count += PL_Text_WriteDxChar(outBuffer + count, ch, maxLen - count);
+    if (bufSize <= 0) {
+        return 0;
     }
     
-    outBuffer[count] = '\0';
+    charset = PL_Text_ToCharset(charset);
+    
+    bufSize -= 1;
+    
+    while (count < bufSize && (ch = PL_Text_ReadChar(&srcStr, charset)) != 0) {
+        dest[count] = ch;
+        count += 1;
+    }
+    
+    dest[count] = '\0';
     
     return count;
 }
 
-int PL_Text_DxStrlen(const DXCHAR *str) {
+int PL_Text_Strlen(const char *str) {
     int i = 0;
     
     while (str[i] != 0) {
@@ -268,9 +284,9 @@ int PL_Text_DxStrlen(const DXCHAR *str) {
     return i;
 }
 
-DXCHAR *PL_Text_DxStrdup(const DXCHAR *str) {
-    int len = PL_Text_DxStrlen(str);
-    DXCHAR *dest = DXALLOC((unsigned int)(len + 1) * sizeof(DXCHAR));
+char *PL_Text_Strdup(const char *str) {
+    int len = PL_Text_Strlen(str);
+    char *dest = DXALLOC((unsigned int)(len + 1) * sizeof(char));
     int i;
     
     for (i = 0; i < len; ++i) {
@@ -281,62 +297,49 @@ DXCHAR *PL_Text_DxStrdup(const DXCHAR *str) {
     return dest;
 }
 
-void PL_Text_DxStrncat(DXCHAR *str, const DXCHAR *catStr, int maxLen) {
-    int len = PL_Text_DxStrlen(str);
-    DXCHAR *end = str + maxLen - 1;
-    DXCHAR ch;
+int PL_Text_Strncat(char *str, const char *catStr, int bufSize) {
+    int count = 0;
+    char ch;
     
-    str += len;
-    
-    while (str < end && (ch = (*catStr++)) != 0) {
-        *str++ = ch;
+    if (bufSize <= 0) {
+        return 0;
     }
     
-    *str = 0;
-}
-
-void PL_Text_DxStrncpy(DXCHAR *str, const DXCHAR *cpyStr, int maxLen) {
-    DXCHAR *end = str + maxLen - 1;
-    DXCHAR ch;
+    bufSize -= 1;
     
-    while (str < end && (ch = (*cpyStr++)) != 0) {
-        *str++ = ch;
+    while (count < bufSize && (ch = (*catStr++)) != 0) {
+        str[count++] = ch;
     }
     
-    *str = 0;
+    str[count] = 0;
+    return count;
 }
 
-void PL_Text_DxStrncatFromString(DXCHAR *str, const char *catStr, int maxLen, int charSet) {
-    int len = PL_Text_DxStrlen(str);
-    unsigned int ch;
+int PL_Text_Strncpy(char *str, const char *cpyStr, int bufSize) {
+    int count = 0;
+    char ch;
     
-    str += len;
-    maxLen -= len + 1;
-    
-    while ((ch = PL_Text_ReadChar(&catStr, charSet)) != 0 && maxLen > 0) {
-        int count = PL_Text_WriteDxChar(str, ch, maxLen);
-        maxLen -= count;
-        str += count;
+    if (bufSize <= 0) {
+        return 0;
     }
     
-    *str = 0;
-}
-
-void PL_Text_DxStrncpyFromString(DXCHAR *str, const char *cpyStr, int maxLen, int charSet) {
-    unsigned int ch;
+    bufSize -= 1;
     
-    maxLen -= 1;
-    
-    while ((ch = PL_Text_ReadChar(&cpyStr, charSet)) != 0 && maxLen > 0) {
-        int count = PL_Text_WriteDxChar(str, ch, maxLen);
-        maxLen -= count;
-        str += count;
+    while (count < bufSize && (ch = (*cpyStr++)) != 0) {
+        str[count++] = ch;
     }
     
-    *str = 0;
+    str[count] = 0;
+    return count;
 }
 
-int PL_Text_DxStrcmp(const DXCHAR *strA, const DXCHAR *strB) {
+int PL_Text_ConvertStrncat(char *dest, int destCharset, const char *srcStr, int srcCharset, int bufSize) {
+    int len = PL_Text_Strlen(dest);
+    
+    return PL_Text_ConvertStrncpy(dest + len, destCharset, srcStr, srcCharset, bufSize - len);
+}
+
+int PL_Text_Strcmp(const char *strA, const char *strB) {
     int v;
     
     while ((v = (*strB - *strA)) == 0 && *strA != 0) {
@@ -346,13 +349,13 @@ int PL_Text_DxStrcmp(const DXCHAR *strA, const DXCHAR *strB) {
     
     return v;
 }
-int PL_Text_DxStrcasecmp(const DXCHAR *strA, const DXCHAR *strB) {
+int PL_Text_Strcasecmp(const char *strA, const char *strB) {
     unsigned int a, b;
     int v;
     
     do {
-        a = PL_Text_ReadDxChar(&strA);
-        b = PL_Text_ReadDxChar(&strB);
+        a = PL_Text_ReadUTF8Char(&strA);
+        b = PL_Text_ReadUTF8Char(&strB);
         v = b - a;
         if (v != 0) {
             if (a >= 'A' && a <= 'Z') {
@@ -367,9 +370,9 @@ int PL_Text_DxStrcasecmp(const DXCHAR *strA, const DXCHAR *strB) {
     
     return v;
 }
-int PL_Text_DxStrncmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen) {
+int PL_Text_Strncmp(const char *strA, const char *strB, int bufSize) {
     int v = 0;
-    const DXCHAR *end = strA + maxLen;
+    const char *end = strA + bufSize;
     
     while (strA < end && (v = (*strB - *strA)) == 0 && *strA != 0) {
         strA += 1;
@@ -378,14 +381,14 @@ int PL_Text_DxStrncmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen) {
     
     return v;
 }
-int PL_Text_DxStrncasecmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen) {
-    const DXCHAR *endA = strA + maxLen;
+int PL_Text_Strncasecmp(const char *strA, const char *strB, int bufSize) {
+    const char *endA = strA + bufSize;
     unsigned int a, b;
     int v;
     
     do {
-        a = PL_Text_ReadDxChar(&strA);
-        b = PL_Text_ReadDxChar(&strB);
+        a = PL_Text_ReadUTF8Char(&strA);
+        b = PL_Text_ReadUTF8Char(&strB);
         v = b - a;
         if (v != 0) {
             if (a >= 'A' && a <= 'Z') {
@@ -400,43 +403,43 @@ int PL_Text_DxStrncasecmp(const DXCHAR *strA, const DXCHAR *strB, int maxLen) {
     
     return v;
 }
-const DXCHAR *PL_Text_DxStrstr(const DXCHAR *strA, const DXCHAR *strB) {
-    int n = PL_Text_DxStrlen(strB);
+const char *PL_Text_Strstr(const char *strA, const char *strB) {
+    int n = PL_Text_Strlen(strB);
     while (*strA) {
-        if (!PL_Text_DxStrncmp(strA, strB, n)) {
+        if (!PL_Text_Strncmp(strA, strB, n)) {
             return strA;
         }
-        PL_Text_ReadDxChar(&strA);
+        PL_Text_ReadUTF8Char(&strA);
     }
     return NULL;
 }
-const DXCHAR *PL_Text_DxStrcasestr(const DXCHAR *strA, const DXCHAR *strB) {
-    int n = PL_Text_DxStrlen(strB);
+const char *PL_Text_Strcasestr(const char *strA, const char *strB) {
+    int n = PL_Text_Strlen(strB);
     while (*strA) {
-        if (!PL_Text_DxStrncasecmp(strA, strB, n)) {
+        if (!PL_Text_Strncasecmp(strA, strB, n)) {
             return strA;
         }
-        PL_Text_ReadDxChar(&strA);
+        PL_Text_ReadUTF8Char(&strA);
     }
     return NULL;
 }
-int PL_Text_DxStrTestExt(const DXCHAR *str, const DXCHAR *ext) {
-    int slen = PL_Text_DxStrlen(str);
-    int elen = PL_Text_DxStrlen(ext);
-    const DXCHAR *target = str + slen - elen;
+int PL_Text_StrTestExt(const char *str, const char *ext) {
+    int slen = PL_Text_Strlen(str);
+    int elen = PL_Text_Strlen(ext);
+    const char *target = str + slen - elen;
     
     if (slen < elen) {
         return DXFALSE;
     }
     
     while (str < target) {
-        PL_Text_ReadDxChar(&str);
+        PL_Text_ReadUTF8Char(&str);
     }
     if (str != target) {
         return DXFALSE;
     }
     
-    if (PL_Text_DxStrcasecmp(str, ext) == 0) {
+    if (PL_Text_Strcasecmp(str, ext) == 0) {
         return DXTRUE;
     }
     return DXFALSE;
@@ -448,27 +451,7 @@ int PL_Text_IsIncompleteMultibyte(const char *string, int length, int charset) {
         case DX_CHARSET_SHFTJIS:
             return PL_Text_IsIncompleteSJISChar(string, length);
 #endif
-        case DX_CHARSET_EXT_UTF8:
+        default: /* case DX_CHARSET_EXT_UTF8: */
             return PL_Text_IsIncompleteUTF8Char(string, length);
-        default:
-            return PL_Text_IsIncompleteMultibyte(string, length, s_useCharSet);
     }
-}
-
-int PL_Text_SetUseCharSet(int charset) {
-    switch(charset) {
-#ifndef DXPORTLIB_NO_SJIS
-        case DX_CHARSET_SHFTJIS: break;
-#endif /* #ifndef DXPORTLIB_NON_SJIS */
-        case DX_CHARSET_EXT_UTF8: break;
-        default: return -1;
-    }
-    
-    s_useCharSet = charset;
-    
-    return 0;
-}
-
-int PL_Text_GetUseCharSet(int charset) {
-    return s_useCharSet;
 }

--- a/src/PL/PLTextSnprintf.c
+++ b/src/PL/PLTextSnprintf.c
@@ -22,7 +22,10 @@
 #include "PLInternal.h"
 
 /* Not all platforms have these, so we implement our own, with custom
- * locale support. Suffering. */
+ * locale support. Suffering.
+ *
+ * Loosely based on SDL2's code, also MIT license.
+ */
  
 typedef struct s_PrintParams {
     int justifyLeft;
@@ -413,11 +416,14 @@ int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, 
                         if (intLevel < 2) {
                             intLevel += 1;
                         }
+                        contFlag = 1;
+                        format += 1;
                         break;
                     case 'I': /* I64 prefix */
                         if (PL_Text_Strncmp(format, "I64", 3) == 0) {
                             format += 3;
                             intLevel = 2;
+                            contFlag = 1;
                         }
                         break;
                     

--- a/src/PL/PLTextSnprintf.c
+++ b/src/PL/PLTextSnprintf.c
@@ -1,0 +1,658 @@
+/*
+  DxPortLib - A portability library for DxLib-based software.
+  Copyright (C) 2013-2016 Patrick McCarthy <mauve@sandwich.net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+    
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "PLInternal.h"
+
+/* Not all platforms have these, so we implement our own, with custom
+ * locale support. Suffering. */
+ 
+typedef struct s_PrintParams {
+    int justifyLeft;
+    int forceSign;
+    int forceType;
+    char pad;
+    int caseLevel;
+
+    int width;
+    int precision;
+    int radix;
+    int charset;
+} s_PrintParams;
+
+static int s_printString(char *dest, const char *end, s_PrintParams *params, const char *str) {
+    char *start = dest;
+    
+    if (params->width > 0) {
+        char filler = params->pad;
+        int len = PL_Text_Strlen(str);
+        int width = params->width;
+        
+        while (width > len && dest < end) {
+            *dest++ = filler;
+            width -= 1;
+        }
+    }
+    
+    PL_Text_Strncpy(dest, str, end - dest + 1);
+    
+    if (params->caseLevel == -1) {
+        PL_Text_StrLower(dest, params->charset);
+    } else if (params->caseLevel == 1) {
+        PL_Text_StrUpper(dest, params->charset);
+    }
+    
+    return dest - start;
+}
+
+static int s_printWString(char *dest, const char *end, s_PrintParams *params, const wchar_t *str) {
+    char *start = dest;
+    
+    if (params->width > 0) {
+        char filler = params->pad;
+        int len = PL_Text_StrlenW(str);
+        int width = params->width;
+        
+        while (width > len && dest < end) {
+            *dest++ = filler;
+            width -= 1;
+        }
+    }
+    
+    PL_Text_WideCharToString(dest, params->charset, str, end - dest + 1);
+    
+    if (params->caseLevel == -1) {
+        PL_Text_StrLower(dest, params->charset);
+    } else if (params->caseLevel == 1) {
+        PL_Text_StrUpper(dest, params->charset);
+    }
+    
+    return dest - start;
+}
+
+static int s_printStringW(wchar_t *dest, const wchar_t *end, s_PrintParams *params, const char *str) {
+    wchar_t *start = dest;
+    
+    if (params->width > 0) {
+        char filler = params->pad;
+        int len = PL_Text_Strlen(str);
+        int width = params->width;
+        
+        while (width > len && dest < end) {
+            *dest++ = filler;
+            width -= 1;
+        }
+    }
+    
+    PL_Text_StringToWideChar(dest, str, params->charset, end - dest + 1);
+    
+    if (params->caseLevel == -1) {
+        PL_Text_StrLowerW(dest);
+    } else if (params->caseLevel == 1) {
+        PL_Text_StrUpperW(dest);
+    }
+    
+    return dest - start;
+}
+static int s_printWStringW(wchar_t *dest, const wchar_t *end, s_PrintParams *params, const wchar_t *str) {
+    wchar_t *start = dest;
+    
+    if (params->width > 0) {
+        char filler = params->pad;
+        int len = PL_Text_StrlenW(str);
+        int width = params->width;
+        
+        while (width > len && dest < end) {
+            *dest++ = filler;
+            width -= 1;
+        }
+    }
+    
+    PL_Text_StrncpyW(dest, str, end - dest + 1);
+    
+    if (params->caseLevel == -1) {
+        PL_Text_StrLowerW(dest);
+    } else if (params->caseLevel == 1) {
+        PL_Text_StrUpperW(dest);
+    }
+    
+    return dest - start;
+}
+
+static const unsigned char s_radixTable[] = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+    'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+    'u', 'v', 'w', 'x', 'y', 'z'
+};
+static const int s_radixTableLen = sizeof(s_radixTable) / sizeof(s_radixTable[0]);
+
+static void s_reverseString(char *start, char *end) {
+    end -= 1;
+    while (start < end) {
+        char c = *end;
+        *end = *start;
+        *start = c;
+        
+        start += 1;
+        end -= 1;
+    }
+}
+
+static int s_printUnsignedLong(char *dest, const char *end, s_PrintParams *params, unsigned long value) {
+    char *start = dest;
+    if (dest == end) {
+        return dest - start;
+    }
+    
+    if (params->radix < 0 || params->radix >= s_radixTableLen) {
+        params->radix = 10;
+    }
+    
+    if (params->radix == 16) {
+        if ((end-dest) >= 2) {
+            *dest++ = '0';
+            *dest++ = 'x';
+        }
+    }
+    
+    if (value == 0) {
+        *dest++ = '0';
+    } else {
+        char *numstart = dest;
+        int radix = params->radix;
+        while (value > 0 && dest < end) {
+            *dest++ = s_radixTable[value % radix];
+            value /= radix;
+        }
+        s_reverseString(numstart, dest);
+    }
+    
+    *dest = 0;
+    return dest - start;
+}
+
+static int s_printUint64(char *dest, const char *end, s_PrintParams *params, uint64_t value) {
+    char *start = dest;
+    if (dest == end) {
+        return dest - start;
+    }
+    
+    if (params->radix < 0 || params->radix >= s_radixTableLen) {
+        params->radix = 10;
+    }
+    
+    if (params->radix == 16) {
+        if ((end-dest) >= 2) {
+            *dest++ = '0';
+            *dest++ = 'x';
+        }
+    }
+    
+    if (value == 0) {
+        *dest++ = '0';
+    } else {
+        char *numstart = dest;
+        int radix = params->radix;
+        while (value > 0 && dest < end) {
+            *dest++ = s_radixTable[value % radix];
+            value /= radix;
+        }
+        s_reverseString(numstart, dest);
+    }
+    *dest = 0;
+    return dest - start;
+}
+static int s_printLong(char *dest, const char *end, s_PrintParams *params, long value) {
+    char *start = dest;
+    if (dest == end) {
+        return dest - start;
+    }
+    if (value < 0) {
+        *dest++ = '-';
+        value = -value;
+    } else if (params->forceSign != 0) {
+        *dest++ = '+';
+    }
+    s_printUnsignedLong(dest, end, params, (unsigned long)value);
+    return dest - start;
+}
+static int s_printSint64(char *dest, const char *end, s_PrintParams *params, int64_t value) {
+    char *start = dest;
+    if (dest == end) {
+        return dest - start;
+    }
+    if (value < 0) {
+        *dest++ = '-';
+        value = -value;
+    } else if (params->forceSign != 0) {
+        *dest++ = '+';
+    }
+    s_printUint64(dest, end, params, (uint64_t)value);
+    return dest - start;
+}
+
+static int s_printDouble(char *dest, const char *end, s_PrintParams *params, double value) {
+    char *start = dest;
+    double floorV;
+    int radix = params->radix;
+    
+    if (dest == end) {
+        return dest - start;
+    }
+    
+    if (radix < 0 || radix >= s_radixTableLen) {
+        radix = 10;
+    }
+    
+    if (value < 0) {
+        *dest++ = '-';
+        value = -value;
+    } else if (params->forceSign != 0) {
+        *dest++ = '+';
+    }
+    
+    if (dest == end) {
+        return dest - start;
+    }
+    
+    /* Handle numeric part. */
+    floorV = floor(value);
+    if (floorV == 0) {
+        *dest++ = '0';
+    } else {
+        char *start = dest;
+        value -= floorV;
+        
+        /* Slooooow */
+        do {
+            double v = floorV / radix;
+            int c;
+            
+            floorV = floor(v);
+            c = (int)floor((v - floorV) * radix);
+            
+            *dest++ = s_radixTable[c];
+        } while (floorV > 0 && dest < end);
+        
+        s_reverseString(start, dest);
+    }
+    
+    /* Handle fractional part. */
+    if (value > 0 && dest < end && params->precision != 0) {
+        int precision = params->precision;
+        if (precision < 0) {
+            precision = 6;
+        }
+        
+        *dest++ = '.';
+        
+        while (value > 0 && precision != 0 && dest < end) {
+            int c;
+            value *= radix;
+            
+            c = (int)floor(value);
+            *dest++ = s_radixTable[c];
+            
+            value -= c;
+        }
+    }
+    
+    *dest = '\0';
+    return dest - start;
+}
+
+static const int s_numBufSize = 255;
+
+int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, va_list args) {
+    char ch;
+    char *start = dest;
+    const char *end = dest + bufSize - 1;
+    
+    while ((ch = *format) != 0 && dest < end) {
+        if (ch != '%') {
+            *dest++ = ch;
+            format += 1;
+        } else {
+            s_PrintParams params;
+            char numBuf[s_numBufSize + 1];
+            int intLevel = 0;
+            int contFlag;
+
+            params.justifyLeft = 0;
+            params.forceSign = 0;
+            params.forceType = 0;
+            params.pad = ' ';
+            params.precision = -1;
+            params.caseLevel = 0;
+            params.width = 0;
+            params.charset = charset;
+            params.radix = 10;
+            
+            /* Read flags for printing */
+            contFlag = 1;
+            do {
+                format += 1;
+                switch (*format) {
+                    case '0':
+                        params.pad = '0';
+                        break;
+                    case '-':
+                        params.justifyLeft = 1;
+                        break;
+                    case '+':
+                        params.forceSign = 1;
+                        break;
+                    case '#':
+                        params.forceType = 1;
+                        break;
+                    default:
+                        contFlag = 0;
+                }
+            } while (contFlag != 0);
+            
+            if (*format >= '0' && *format <= '9') {
+                params.width = 0;
+                do {
+                    params.width *= 10;
+                    params.width += *format - '0';
+                    format += 1;
+                } while (*format >= '0' && *format <= '9');
+            }
+            if (*format == '.') {
+                format += 1;
+                params.precision = 0;
+                do {
+                    params.precision *= 10;
+                    params.precision += *format - '0';
+                    format += 1;
+                } while (*format >= '0' && *format <= '9');
+            }
+            
+            do {
+                contFlag = 0;
+                switch(*format) {
+                    case '%': /* %, as-is */
+                        *dest++ = '%';
+                        break;
+                    case 'c': /* char */
+                        *dest++ = (char)va_arg(args, int);
+                        break;
+                    case 's': /* string */
+                        if (intLevel == 0) {
+                            dest += s_printString(dest, end, &params, va_arg(args, const char *));
+                        } else {
+                            dest += s_printWString(dest, end, &params, va_arg(args, const wchar_t *));
+                        }
+                    case 'S':
+                        dest += s_printWString(dest, end, &params, va_arg(args, const wchar_t *));
+                        break;
+                    
+                    case 'h': /* prefix for short */
+                        contFlag = 1; /* short becomes int */
+                        format += 1;
+                        break;
+                    case 'l': /* long prefix, can stack */
+                        if (intLevel < 2) {
+                            intLevel += 1;
+                        }
+                        break;
+                    case 'I': /* I64 prefix */
+                        if (PL_Text_Strncmp(format, "I64", 3) == 0) {
+                            format += 3;
+                            intLevel = 2;
+                        }
+                        break;
+                    
+                    case 'i': /* integer */
+                    case 'd': /* also integer */
+                        switch(intLevel) {
+                            case 0: /* int */
+                                s_printLong(numBuf, numBuf + s_numBufSize, &params, (long)va_arg(args, int));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                            case 1: /* long */
+                                s_printLong(numBuf, numBuf + s_numBufSize, &params, va_arg(args, long));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                            case 2: /* long long */
+                                s_printSint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, long long));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                        }
+                        break;
+                        
+                    /* Hex, unsigned, octal, etc printing modes, all fall through */
+                    case 'p': /* pointer */
+                        intLevel = 1; /* pointers are always longs */
+                    case 'x': /* hexadecimal */
+                        params.caseLevel = -1;
+                    case 'X': /* capitalized hex */
+                        if (params.caseLevel == 0) {
+                            params.caseLevel = 1;
+                        }
+                        if (params.radix == 10) {
+                            params.radix = 16;
+                        }
+                    case 'o': /* octal */
+                        if (params.radix == 10) {
+                            params.radix = 8;
+                        }
+                    case 'u': /* unsigned */
+                        params.pad = '0';
+                        switch(intLevel) {
+                            case 0: /* int */
+                                s_printUnsignedLong(numBuf, numBuf + s_numBufSize, &params, (unsigned long)va_arg(args, unsigned int));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                            case 1: /* long */
+                                s_printUnsignedLong(numBuf, numBuf + s_numBufSize, &params, va_arg(args, unsigned long));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                            case 2: /* long long */
+                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, uint64_t));
+                                dest += s_printString(dest, end, &params, numBuf);
+                                break;
+                        }
+                        break;
+                    case 'f': /* float */
+                        s_printDouble(numBuf, numBuf + s_numBufSize, &params, va_arg(args, double));
+                        dest += s_printString(dest, end, &params, numBuf);
+                        break;
+                    default:
+                        break;
+                }
+            } while (contFlag != 0);
+        }
+    }
+    
+    *dest = 0;
+    
+    return dest - start;
+}
+
+int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
+                       const wchar_t *format, va_list args)
+{
+    wchar_t ch;
+    wchar_t *start = dest;
+    const wchar_t *end = dest + bufSize - 1;
+    
+    while ((ch = *format) != 0 && dest < end) {
+        if (ch != '%') {
+            *dest++ = ch;
+            format += 1;
+        } else {
+            s_PrintParams params;
+            char numBuf[s_numBufSize + 1];
+            int intLevel = 0;
+            int contFlag;
+
+            params.justifyLeft = 0;
+            params.forceSign = 0;
+            params.forceType = 0;
+            params.pad = ' ';
+            params.precision = -1;
+            params.caseLevel = 0;
+            params.width = 0;
+            params.charset = charset;
+            params.radix = 10;
+            
+            /* Read flags for printing */
+            contFlag = 1;
+            do {
+                format += 1;
+                switch (*format) {
+                    case '0':
+                        params.pad = '0';
+                        break;
+                    case '-':
+                        params.justifyLeft = 1;
+                        break;
+                    case '+':
+                        params.forceSign = 1;
+                        break;
+                    case '#':
+                        params.forceType = 1;
+                        break;
+                    default:
+                        contFlag = 0;
+                }
+            } while (contFlag != 0);
+            
+            if (*format >= '0' && *format <= '9') {
+                params.width = 0;
+                do {
+                    params.width *= 10;
+                    params.width += *format - '0';
+                    format += 1;
+                } while (*format >= '0' && *format <= '9');
+            }
+            if (*format == '.') {
+                format += 1;
+                params.precision = 0;
+                do {
+                    params.precision *= 10;
+                    params.precision += *format - '0';
+                    format += 1;
+                } while (*format >= '0' && *format <= '9');
+            }
+            
+            do {
+                contFlag = 0;
+                switch(*format) {
+                    case '%': /* %, as-is */
+                        *dest++ = '%';
+                        break;
+                    case 'c': /* char */
+                        *dest++ = (char)va_arg(args, int);
+                        break;
+                    case 's': /* string */
+                        if (intLevel == 0) {
+                            dest += s_printStringW(dest, end, &params, va_arg(args, const char *));
+                        } else {
+                            dest += s_printWStringW(dest, end, &params, va_arg(args, const wchar_t *));
+                        }
+                    case 'S':
+                        dest += s_printWStringW(dest, end, &params, va_arg(args, const wchar_t *));
+                        break;
+                    
+                    case 'h': /* prefix for short */
+                        contFlag = 1; /* short becomes int */
+                        format += 1;
+                        break;
+                    case 'l': /* long prefix, can stack */
+                        if (intLevel < 2) {
+                            intLevel += 1;
+                        }
+                        break;
+                    case 'I': /* I64 prefix */
+                        if (PL_Text_StrncmpW(format, L"I64", 3) == 0) {
+                            format += 3;
+                            intLevel = 2;
+                        }
+                        break;
+                    
+                    case 'i': /* integer */
+                    case 'd': /* also integer */
+                        switch(intLevel) {
+                            case 0: /* int */
+                                s_printLong(numBuf, numBuf + s_numBufSize, &params, (long)va_arg(args, int));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                            case 1: /* long */
+                                s_printLong(numBuf, numBuf + s_numBufSize, &params, va_arg(args, long));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                            case 2: /* long long */
+                                s_printSint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, long long));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                        }
+                        break;
+                        
+                    /* Hex, unsigned, octal, etc printing modes, all fall through */
+                    case 'p': /* pointer */
+                        intLevel = 1; /* pointers are always longs */
+                    case 'x': /* hexadecimal */
+                        params.caseLevel = -1;
+                    case 'X': /* capitalized hex */
+                        if (params.caseLevel == 0) {
+                            params.caseLevel = 1;
+                        }
+                        if (params.radix == 10) {
+                            params.radix = 16;
+                        }
+                    case 'o': /* octal */
+                        if (params.radix == 10) {
+                            params.radix = 8;
+                        }
+                    case 'u': /* unsigned */
+                        params.pad = '0';
+                        switch(intLevel) {
+                            case 0: /* int */
+                                s_printUnsignedLong(numBuf, numBuf + s_numBufSize, &params, (unsigned long)va_arg(args, unsigned int));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                            case 1: /* long */
+                                s_printUnsignedLong(numBuf, numBuf + s_numBufSize, &params, va_arg(args, unsigned long));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                            case 2: /* long long */
+                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, uint64_t));
+                                dest += s_printStringW(dest, end, &params, numBuf);
+                                break;
+                        }
+                        break;
+                    case 'f': /* float */
+                        s_printDouble(numBuf, numBuf + s_numBufSize, &params, va_arg(args, float));
+                        dest += s_printStringW(dest, end, &params, numBuf);
+                        break;
+                    default:
+                        break;
+                }
+            } while (contFlag != 0);
+        }
+    }
+    
+    *dest = 0;
+    
+    return dest - start;
+}

--- a/src/PL/PLTextSnprintf.c
+++ b/src/PL/PLTextSnprintf.c
@@ -467,7 +467,7 @@ int PL_Text_Vsnprintf(char *dest, int bufSize, int charset, const char *format, 
                                 dest += s_printString(dest, end, &params, numBuf);
                                 break;
                             case 2: /* long long */
-                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, uint64_t));
+                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, (uint64_t)va_arg(args, unsigned long long));
                                 dest += s_printString(dest, end, &params, numBuf);
                                 break;
                         }
@@ -636,13 +636,13 @@ int PL_Text_Wvsnprintf(wchar_t *dest, int bufSize, int charset,
                                 dest += s_printStringW(dest, end, &params, numBuf);
                                 break;
                             case 2: /* long long */
-                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, va_arg(args, uint64_t));
+                                s_printUint64(numBuf, numBuf + s_numBufSize, &params, (uint64_t)va_arg(args, unsigned long long));
                                 dest += s_printStringW(dest, end, &params, numBuf);
                                 break;
                         }
                         break;
                     case 'f': /* float */
-                        s_printDouble(numBuf, numBuf + s_numBufSize, &params, va_arg(args, float));
+                        s_printDouble(numBuf, numBuf + s_numBufSize, &params, va_arg(args, double));
                         dest += s_printStringW(dest, end, &params, numBuf);
                         break;
                     default:

--- a/src/PL/PLTextSscanf.c
+++ b/src/PL/PLTextSscanf.c
@@ -1,0 +1,34 @@
+/*
+  DxPortLib - A portability library for DxLib-based software.
+  Copyright (C) 2013-2016 Patrick McCarthy <mauve@sandwich.net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+    
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "PLInternal.h"
+
+/* Not all platforms have these, so we implement our own, with custom
+ * locale support. Suffering. */
+ 
+/* Currently stubs. */
+
+int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args) {
+    return 0;
+}
+int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args) {
+    return 0;
+}

--- a/src/PL/PLTextSscanf.c
+++ b/src/PL/PLTextSscanf.c
@@ -22,13 +22,499 @@
 #include "PLInternal.h"
 
 /* Not all platforms have these, so we implement our own, with custom
- * locale support. Suffering. */
- 
-/* Currently stubs. */
+ * locale support. Suffering.
+ *
+ * Loosely based on SDL2's code, also MIT license.
+ */
 
-int PL_Text_Vsscanf(const char *buf, int bufSize, int charset, const char *format, va_list args) {
-    return 0;
+static int s_isSpace(unsigned int c) {
+    return (c == ' ') || (c == '\n') || (c == '\r') || (c == '\t') || (c == '\f') || (c == '\v');
 }
-int PL_Text_Wvsscanf(const wchar_t *buf, int bufSize, int charset, const wchar_t *format, va_list args) {
-    return 0;
+
+static int s_scanUnsignedLong(const char *str, int charset, int radix, unsigned long *value) {
+    const char *start = str;
+    int negFlag = 0;
+    unsigned long v = 0;
+    unsigned int c;
+    
+    /* Test for 0x */
+    if (radix == 16) {
+        const char *tmp = str;
+        c = PL_Text_ReadChar(&str, charset);
+        if (c == '0' && radix == 16) {
+            c = PL_Text_ReadChar(&str, charset);
+            if (c == 'x' || c == 'X') {
+                tmp = str;
+            }
+        }
+        str = tmp;
+    }
+     
+    /* Break down the numbers. */
+    while (*str) {
+        const char *thisStart = str;
+        c = PL_Text_ReadChar(&str, charset);
+        int cv = 0;
+        if (c >= '0' && c <= '9') {
+            cv = c - '0';
+        } else if (c >= 'a' && c <= 'z') {
+            cv = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'Z') {
+            cv = c - 'A' + 10;
+        } else {
+            str = thisStart;
+            break;
+        }
+        if (cv >= 0 && cv < radix) {
+            v = (v * radix) + cv;
+        } else {
+            str = thisStart;
+            break;
+        }
+    }
+    
+    if (negFlag) {
+        v = -v;
+    }
+    *value = v;
+    
+    return str - start;
+}
+
+static int s_scanLong(const char *str, int charset, int radix, long *value) {
+    const char *start = str;
+    unsigned int c = PL_Text_ReadChar(&str, charset);
+    int negFlag = 0;
+    unsigned long uv;
+    long v;
+    
+    if (c == '-') {
+        negFlag = 1;
+    } else {
+        str = start;
+    }
+    
+    str += s_scanUnsignedLong(str, charset, radix, &uv);
+    
+    v = (long)uv;
+    if (negFlag) {
+        v = -uv;
+    }
+    *value = v;
+    
+    return str - start;
+}
+
+static int s_scanUint64(const char *str, int charset, int radix, uint64_t *value) {
+    const char *start = str;
+    int negFlag = 0;
+    uint64_t v = 0;
+    unsigned int c;
+    
+    /* Test for 0x */
+    if (radix == 16) {
+        const char *tmp = str;
+        c = PL_Text_ReadChar(&str, charset);
+        if (c == '0' && radix == 16) {
+            c = PL_Text_ReadChar(&str, charset);
+            if (c == 'x' || c == 'X') {
+                tmp = str;
+            }
+        }
+        str = tmp;
+    }
+     
+    /* Break down the numbers. */
+    while (*str) {
+        const char *thisStart = str;
+        c = PL_Text_ReadChar(&str, charset);
+        int cv = 0;
+        if (c >= '0' && c <= '9') {
+            cv = c - '0';
+        } else if (c >= 'a' && c <= 'z') {
+            cv = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'Z') {
+            cv = c - 'A' + 10;
+        } else {
+            str = thisStart;
+            break;
+        }
+        if (cv >= 0 && cv < radix) {
+            v = (v * radix) + cv;
+        } else {
+            str = thisStart;
+            break;
+        }
+    }
+    
+    if (negFlag) {
+        v = -v;
+    }
+    *value = v;
+    
+    return str - start;
+}
+
+static int s_scanSint64(const char *str, int charset, int radix, int64_t *value) {
+    const char *start = str;
+    unsigned int c = PL_Text_ReadChar(&str, charset);
+    int negFlag = 0;
+    uint64_t uv;
+    int64_t v;
+    
+    if (c == '-') {
+        negFlag = 1;
+    } else {
+        str = start;
+    }
+    
+    str += s_scanUint64(str, charset, radix, &uv);
+    
+    v = (int64_t)uv;
+    if (negFlag) {
+        v = -uv;
+    }
+    *value = v;
+    
+    return str - start;
+}
+
+static int s_scanDouble(const char *str, int charset, int radix, double *value) {
+    const char *start = str;
+    const char *tmp;
+    unsigned int c = PL_Text_ReadChar(&str, charset);
+    double v = 0;
+    int negFlag = 0;
+    
+    if (c == '-') {
+        negFlag = 1;
+    } else {
+        str = start;
+    }
+    
+    while (*str) {
+        tmp = str;
+        c = PL_Text_ReadChar(&str, charset);
+        int cv = 0;
+        if (c >= '0' || c <= '9') {
+            cv = c - '0';
+        } else if (c >= 'a' && c <= 'z') {
+            cv = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'Z') {
+            cv = c - 'A' + 10;
+        } else {
+            str = tmp;
+            break;
+        }
+        
+        if (cv >= radix) {
+            str = tmp;
+            break;
+        }
+        
+        v = (v * radix) + (cv * 10);
+    }
+    
+    tmp = str;
+    c = PL_Text_ReadChar(&str, charset);
+    if (c == '.') {
+        double divisor = 1.0 / radix;
+        double d = divisor;
+        while (*str) {
+            tmp = str;
+            c = PL_Text_ReadChar(&str, charset);
+            int cv = 0;
+            if (c >= '0' || c <= '9') {
+                cv = c - '0';
+            } else if (c >= 'a' && c <= 'z') {
+                cv = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'Z') {
+                cv = c - 'A' + 10;
+            } else {
+                str = tmp;
+                break;
+            }
+            
+            if (cv >= radix) {
+                str = tmp;
+                break;
+            }
+            
+            v += cv * d;
+            d *= divisor;
+        }
+    }
+    
+    if (negFlag) {
+        v = -v;
+    }
+    
+    *value = v;
+    
+    return str - start;
+}
+
+int PL_Text_Vsscanf(const char *str, int charset, const char *format, va_list args) {
+    int count = 0;
+    char ch;
+    
+    while ((ch = *format) != 0) {
+        if (ch == ' ') {
+            while (s_isSpace(*str) != 0) {
+                str += 1;
+            }
+            format += 1;
+            continue;
+        } else if (ch == '%') {
+            int radix = 10;
+            int intLevel = 1;
+            long size = 0;
+            int contFlag;
+            int ignoreFlag = 0;
+            
+            format += 1;
+            if (*format == '%') {
+                if (*str == '%') {
+                    str += 1;
+                    format += 1;
+                }
+                continue;
+            }
+            if (*format == '*') {
+                ignoreFlag = 1;
+                format += 1;
+            }
+            
+            format += s_scanLong(format, charset, 10, &size);
+            if (size < 0) {
+                size = 0;
+            }
+            
+            while (s_isSpace(*str) != 0) {
+                PL_Text_ReadChar(&str, charset);
+            }
+            
+            do {
+                contFlag = 0;
+                switch(*format) {
+                    case '*':
+                        ignoreFlag = 1;
+                        contFlag = 1;
+                        format += 1;
+                        break;
+                    case 'h':
+                        if (intLevel > 0) {
+                            intLevel -= 1;
+                        }
+                        contFlag = 1;
+                        format += 1;
+                        break;
+                    case 'l':
+                        if (intLevel < 3) {
+                            intLevel += 1;
+                        }
+                        contFlag = 1;
+                        format += 1;
+                        break;
+                    case 'I':
+                        if (PL_Text_Strncmp(format, "I64", 3) == 0) {
+                            intLevel = 3;
+                            format += 3;
+                            contFlag = 1;
+                        }
+                        break;
+                    
+                    case 'i':
+                        {
+                            /* for %i, extract radix automatically */
+                            const char *tmp = str;
+                            if (*tmp == '-') {
+                                tmp += 1;
+                            }
+                            if (*tmp == '0') {
+                                if (tmp[1] == 'x' || tmp[1] == 'X') {
+                                    radix = 16;
+                                } else {
+                                    radix = 8;
+                                }
+                            }
+                        }
+                        /* Fall through */
+                    case 'd':
+                        if (intLevel == 3) {
+                            int64_t value;
+                            str += s_scanSint64(str, charset, radix, &value);
+                            if (ignoreFlag == 0) {
+                                long long *target = va_arg(args, long long *);
+                                *target = value;
+                                count += 1;
+                            }
+                        } else {
+                            long value;
+                            str += s_scanLong(str, charset, radix, &value);
+                            if (ignoreFlag == 0) {
+                                if (intLevel == 2) {
+                                    long *target = va_arg(args, long *);
+                                    *target = value;
+                                } else if (intLevel == 1) {
+                                    int *target = va_arg(args, int *);
+                                    *target = (int)value;
+                                } else if (intLevel == 0) {
+                                    short *target = va_arg(args, short *);
+                                    *target = (short)value;
+                                }
+                                count += 1;
+                            }
+                        }
+                        break;
+                    case 'o':
+                        if (radix == 10) {
+                            radix = 8;
+                        }
+                        /* Fall through */
+                    case 'x':
+                    case 'X':
+                        if (radix == 10) {
+                            radix = 16;
+                        }
+                        /* Fall through */
+                    case 'u':
+                        if (intLevel == 3) {
+                            uint64_t value;
+                            str += s_scanUint64(str, charset, radix, &value);
+                            if (ignoreFlag == 0) {
+                                unsigned long long *target = va_arg(args, unsigned long long *);
+                                *target = value;
+                                count += 1;
+                            }
+                        } else {
+                            unsigned long value;
+                            str += s_scanUnsignedLong(str, charset, radix, &value);
+                            if (ignoreFlag == 0) {
+                                if (intLevel == 2) {
+                                    unsigned long *target = va_arg(args, unsigned long *);
+                                    *target = value;
+                                } else if (intLevel == 1) {
+                                    unsigned int *target = va_arg(args, unsigned int *);
+                                    *target = (int)value;
+                                } else if (intLevel == 0) {
+                                    unsigned short *target = va_arg(args, unsigned short *);
+                                    *target = (short)value;
+                                }
+                                count += 1;
+                            }
+                        }
+                        break;
+                    case 'p':
+                        {
+                            unsigned long value;
+                            str += s_scanUnsignedLong(str, charset, 16, &value);
+                            if (ignoreFlag == 0) {
+                                void **target = va_arg(args, void **);
+                                *target = (void *)value;
+                                count += 1;
+                            }
+                        }
+                        break;
+                    
+                    case 'f':
+                        {
+                            double value;
+                            str += s_scanDouble(str, charset, radix, &value);
+                            if (ignoreFlag == 0) {
+                                if (intLevel > 1) {
+                                    double *target = va_arg(args, double *);
+                                    *target = value;
+                                } else {
+                                    float *target = va_arg(args, float *);
+                                    *target =value;
+                                }
+                                count += 1;
+                            }
+                        }
+                        
+                        break;
+                                        
+                    case 'c':
+                        if (size <= 0) {
+                            size = 1;
+                        }
+                        if (ignoreFlag != 0) {
+                            while (*str != 0 && size > 0) {
+                                str += 1;
+                                size -= 1;
+                            }
+                        } else {
+                            char *target = va_arg(args, char *);
+                            char *end = target + size;
+                            while (*str != 0) {
+                                unsigned int c = PL_Text_ReadChar(&str, charset);
+                                target += PL_Text_WriteChar(target, c, end - target, charset);
+                                if (target == end) {
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    case 's':
+                        if (ignoreFlag == 0 && intLevel <= 1) {
+                            char *target = va_arg(args, char *);
+                            char *end = target + size;
+                            while (*str != 0 && s_isSpace(*str) == 0) {
+                                unsigned int c = PL_Text_ReadChar(&str, charset);
+                                target += PL_Text_WriteChar(target, c, end - target, charset);
+                                if (target == end) {
+                                    break;
+                                }
+                            }
+                            *target = '\0';
+                            break;
+                        }
+                        /* Fall through to widechar string / ignore logic */
+                    case 'S':
+                        if (ignoreFlag != 0) {
+                            while (*str != 0 && s_isSpace(*str) == 0) {
+                                str += 1;
+                                if (size > 0) {
+                                    size -= 1;
+                                    if (size == 0) {
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            wchar_t *target = va_arg(args, wchar_t *);
+                            wchar_t *end = target + size;
+                            while (*str != 0 && s_isSpace(*str) == 0) {
+                                unsigned int c = PL_Text_ReadChar(&str, charset);
+                                *target++ = c;
+                                if (target == end) {
+                                    break;
+                                }
+                            }
+                            *target = '\0';
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            } while (contFlag != 0);
+            
+            if (*format) {
+                format += 1;
+            }
+        }
+    }
+    
+    return count;
+}
+
+int PL_Text_Wvsscanf(const wchar_t *str, int charset, const wchar_t *format, va_list args) {
+    char strbuf[4096];
+    char formatbuf[4096];
+    
+    PL_Text_WideCharToString(strbuf, charset, str, 4096);
+    PL_Text_WideCharToString(formatbuf, charset, format, 4096);
+    
+    return PL_Text_Vsscanf(strbuf, charset, formatbuf, args);
 }

--- a/src/PL/SDL2/PLSDL2File.c
+++ b/src/PL/SDL2/PLSDL2File.c
@@ -132,17 +132,11 @@ int PLSDL2_RWopsToFile(SDL_RWops *rwops) {
     }
 }
 
-SDL_RWops *PLSDL2_FileOpenReadDirect(const DXCHAR *filename) {
-    char utf8Buf[2048];
-    
-    if (PL_Text_DxStringToString(filename, utf8Buf, 2048, DX_CHARSET_EXT_UTF8) <= 0) {
-        return NULL;
-    }
-    
-    return SDL_RWFromFile(utf8Buf, "rb");
+SDL_RWops *PLSDL2_FileOpenReadDirect(const char *filename) {
+    return SDL_RWFromFile(filename, "rb");
 }
 
-int PL_Platform_FileOpenReadDirect(const DXCHAR *filename) {
+int PL_Platform_FileOpenReadDirect(const char *filename) {
     SDL_RWops *rwops = PLSDL2_FileOpenReadDirect(filename);
     
     return PLSDL2_RWopsToFile(rwops);

--- a/src/PL/SDL2/PLSDL2Internal.h
+++ b/src/PL/SDL2/PLSDL2Internal.h
@@ -38,6 +38,7 @@ extern void PL_SDL2GL_Init(SDL_Window *window, int width, int height);
 extern int PL_SDL2GL_UpdateVSync(int vsyncFlag);
 extern void PL_SDL2GL_End();
 
+extern SDL_Window *PL_window;
 extern int PL_drawOffscreen;
 
 #endif /* #ifdef DXPORTLIB_PLATFORM_SDL2 */

--- a/src/PL/SDL2/PLSDL2Internal.h
+++ b/src/PL/SDL2/PLSDL2Internal.h
@@ -30,7 +30,7 @@
 
 extern SDL_RWops *PLSDL2_FileToRWops(int fileHandle);
 extern int PLSDL2_RWopsToFile(SDL_RWops *rwops);
-extern SDL_RWops *PLSDL2_FileOpenReadDirect(const DXCHAR *filename);
+extern SDL_RWops *PLSDL2_FileOpenReadDirect(const char *filename);
 
 /* ------------------------------------------------------------- Screen.c */
 

--- a/src/PL/SDL2/PLSDL2Main.c
+++ b/src/PL/SDL2/PLSDL2Main.c
@@ -27,8 +27,6 @@
 
 #include "SDL_image.h"
 
-#include <time.h>
-
 PLIGraphics PLG;
 
 /* For setting the floating precision to the system value.
@@ -69,70 +67,6 @@ void PL_Platform_Init() {
 
 void PL_Platform_Finish() {
     SDL_Quit();
-}
-
-int PL_Platform_GetTicks() {
-    return SDL_GetTicks();
-}
-
-void PL_Platform_Wait(int ticks) {
-    SDL_Delay(ticks);
-}
-
-int PL_Platform_GetDateTime(DATEDATA *dateBuf) {
-    /* SDL does not have a function for getting system date and time,
-     * so we use time/localtime for this. */
-    time_t t;
-    struct tm *format;
-    
-    time(&t);
-    format = localtime(&t);
-    
-    dateBuf->Year = format->tm_year + 1900;
-    dateBuf->Mon = format->tm_mon + 1;
-    dateBuf->Day = format->tm_mday;
-    dateBuf->Hour = format->tm_hour;
-    dateBuf->Min = format->tm_min;
-    dateBuf->Sec = format->tm_sec;
-    
-    return 0;
-}
-
-int PL_Platform_GetSaveFolder(DXCHAR *buffer, int bufferLength,
-                              const DXCHAR *org, const DXCHAR *app,
-                              int destEncoding) {
-    char *prefPath;
-    
-    if (bufferLength == 0) {
-        return -1;
-    }
-
-#ifdef UNICODE
-    {
-        char orgBuf[4096];
-        char appBuf[4096];
-        PL_Text_DxStringToString(buffer, orgBuf, 4096, DX_CHARSET_EXT_UTF8);
-        PL_Text_DxStringToString(buffer, appBuf, 4096, DX_CHARSET_EXT_UTF8);
-        prefPath = SDL_GetPrefPath(orgBuf, appBuf);
-    }
-#else
-    prefPath = SDL_GetPrefPath(org, app);
-#endif
-    if (prefPath == NULL) {
-        buffer[0] = '\0';
-        return 0;
-    }
-    
-#ifdef UNICODE
-    PL_Text_DxStrncpyFromString(buffer, prefPath, bufferLength,
-                                DX_CHARSET_EXT_UTF8);
-#else
-    PL_Text_ConvertString(prefPath, buffer, bufferLength,
-                          DX_CHARSET_EXT_UTF8, destEncoding);
-#endif
-
-    SDL_free(prefPath);
-    return 0;
 }
 
 #endif /* #ifdef DXPORTLIB_PLATFORM_SDL2 */

--- a/src/PL/SDL2/PLSDL2SaveScreen.c
+++ b/src/PL/SDL2/PLSDL2SaveScreen.c
@@ -28,21 +28,20 @@
 #include "SDL_image.h"
 
 int PL_SaveDrawScreenToBMP(int x1, int y1, int x2, int y2,
-                           const DXCHAR *filename) {
+                           const char *filename) {
     return -1;
 }
 
 int PL_SaveDrawScreenToJPEG(int x1, int y1, int x2, int y2,
-                            const DXCHAR *filename,
+                            const char *filename,
                             int quality, int sample2x1) {
     return -1;
 }
 
 int PL_SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
-                           const DXCHAR *filename,
+                           const char *filename,
                            int compressionLevel) {
     SDL_Surface *surface;
-    char namebuf[4096];
     PLRect rect;
     rect.x = x1;
     rect.y = y1;
@@ -53,9 +52,7 @@ int PL_SaveDrawScreenToPNG(int x1, int y1, int x2, int y2,
         return -1;
     }
     
-    PL_Text_DxStringToString(filename, namebuf, 4096, DX_CHARSET_EXT_UTF8);
-    
-    return IMG_SavePNG(surface, namebuf);
+    return IMG_SavePNG(surface, filename);
 }
 
 #endif

--- a/src/PL/SDL2/PLSDL2System.c
+++ b/src/PL/SDL2/PLSDL2System.c
@@ -1,0 +1,120 @@
+/*
+  DxPortLib - A portability library for DxLib-based software.
+  Copyright (C) 2013-2015 Patrick McCarthy <mauve@sandwich.net>
+  
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+    
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required. 
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "PLSDL2Internal.h"
+
+#ifdef DXPORTLIB_PLATFORM_SDL2
+
+#include "SDL.h"
+
+#include <time.h>
+
+int PL_Platform_GetTicks() {
+    return SDL_GetTicks();
+}
+
+void PL_Platform_Wait(int ticks) {
+    SDL_Delay(ticks);
+}
+
+int PL_Platform_GetDateTime(DATEDATA *dateBuf) {
+    /* SDL does not have a function for getting system date and time,
+     * so we use time/localtime for this. */
+    time_t t;
+    struct tm *format;
+    
+    time(&t);
+    format = localtime(&t);
+    
+    dateBuf->Year = format->tm_year + 1900;
+    dateBuf->Mon = format->tm_mon + 1;
+    dateBuf->Day = format->tm_mday;
+    dateBuf->Hour = format->tm_hour;
+    dateBuf->Min = format->tm_min;
+    dateBuf->Sec = format->tm_sec;
+    
+    return 0;
+}
+
+int PL_Platform_GetSaveFolder(char *buffer, int bufferLength,
+                              const char *org, const char *app,
+                              int destEncoding) {
+    char *prefPath;
+    
+    if (bufferLength == 0) {
+        return -1;
+    }
+
+    prefPath = SDL_GetPrefPath(org, app);
+    if (prefPath == NULL) {
+        buffer[0] = '\0';
+        return 0;
+    }
+    
+    PL_Text_ConvertStrncpy(buffer, destEncoding,
+                           prefPath, DX_CHARSET_EXT_UTF8,
+                           bufferLength);
+
+    SDL_free(prefPath);
+    return 0;
+}
+
+/* System agnostic message box stuff */
+int PL_Platform_MessageBoxError(
+        const DXCHAR *title,
+        const DXCHAR *text
+) {
+    return SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, text, PL_window);
+}
+
+int PL_Platform_MessageBoxYesNo(
+        const char *title,
+        const char *text,
+        const char *yes,
+        const char *no
+) {
+    SDL_MessageBoxButtonData buttons[2];
+    SDL_MessageBoxData data;
+    int resultButton;
+    
+    buttons[0].flags = SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;
+    buttons[0].buttonid = 1;
+    buttons[0].text = yes;
+    buttons[1].flags = SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT;
+    buttons[1].buttonid = 0;
+    buttons[1].text = no;
+    
+    data.flags = SDL_MESSAGEBOX_INFORMATION;
+    data.window = PL_window;
+    data.title = title;
+    data.message = text;
+    data.numbuttons = 2;
+    data.buttons = buttons;
+    data.colorScheme = NULL;
+    
+    if (SDL_ShowMessageBox(&data, &resultButton) < 0) {
+        return -1;
+    }
+    
+    return resultButton;
+}
+
+#endif

--- a/src/PL/SDL2/PLSDL2System.c
+++ b/src/PL/SDL2/PLSDL2System.c
@@ -79,8 +79,8 @@ int PL_Platform_GetSaveFolder(char *buffer, int bufferLength,
 
 /* System agnostic message box stuff */
 int PL_Platform_MessageBoxError(
-        const DXCHAR *title,
-        const DXCHAR *text
+        const char *title,
+        const char *text
 ) {
     return SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, text, PL_window);
 }


### PR DESCRIPTION
Internally now uses UTF8 universally, regardless of UNICODE setting.

Added custom Vsnprintf and Vsscanf, with widechar support, to fill the holes.

Still needs testing.